### PR TITLE
Feature(IL-98): 아이디 및 닉네임 중복 확인 구현

### DIFF
--- a/src/apis/authentication/nicknameDupCheck.jsx
+++ b/src/apis/authentication/nicknameDupCheck.jsx
@@ -1,0 +1,23 @@
+import api from '@/apis/api'
+
+/**닉네임 중복 체크 API */
+const nicknameDupCheck = async (nickname) => {
+  try {
+    const response = await api.get('auth/dup-check/nickname', {
+      params: { value: nickname },
+    })
+    return response.data
+  } catch (err) {
+    if (err.response?.data?.message) {
+      throw new Error(err.response.data.message)
+    } else if (err.response) {
+      throw new Error(`오류 발생 (status: ${err.response.status})`)
+    } else if (err.request) {
+      throw new Error('서버로부터 응답이 없습니다.')
+    } else {
+      throw new Error('요청 중 알 수 없는 오류가 발생했습니다.')
+    }
+  }
+}
+
+export default nicknameDupCheck

--- a/src/apis/authentication/usernameDupCheck.jsx
+++ b/src/apis/authentication/usernameDupCheck.jsx
@@ -1,0 +1,23 @@
+import api from '@/apis/api'
+
+/**아이디 중복 체크 API */
+const usernameDupCheck = async (username) => {
+  try {
+    const response = await api.get('auth/dup-check/username', {
+      params: { value: username },
+    })
+    return response.data
+  } catch (err) {
+    if (err.response?.data?.message) {
+      throw new Error(err.response.data.message)
+    } else if (err.response) {
+      throw new Error(`오류 발생 (status: ${err.response.status})`)
+    } else if (err.request) {
+      throw new Error('서버로부터 응답이 없습니다.')
+    } else {
+      throw new Error('요청 중 알 수 없는 오류가 발생했습니다.')
+    }
+  }
+}
+
+export default usernameDupCheck

--- a/src/components/sign-up/SignUpForm.jsx
+++ b/src/components/sign-up/SignUpForm.jsx
@@ -42,7 +42,8 @@ const SignUpForm = () => {
   const username = watch('username')
   const nickname = watch('nickname')
 
-  const handleDupCheckUsername = async (usernane) => {
+  /**버튼 클릭 시 아이디 중복 확인 API 호출 */
+  const handleDupCheckUsername = async () => {
     try {
       const result = await usernameDupCheck(username)
       alert(result.message)
@@ -53,7 +54,8 @@ const SignUpForm = () => {
     }
   }
 
-  const handleDupCheckNickname = async (nickname) => {
+  /**버튼 클릭 시 닉네임 중복 확인 API 호출 */
+  const handleDupCheckNickname = async () => {
     try {
       const result = await nicknameDupCheck(nickname)
       alert(result.message)
@@ -77,13 +79,7 @@ const SignUpForm = () => {
             placeholder='ID'
             className='flex-1'
           />
-          <button
-            onClick={() => {
-              handleDupCheckUsername(username)
-            }}
-          >
-            중복 확인
-          </button>
+          <button onClick={handleDupCheckUsername}>중복 확인</button>
         </div>
         <input
           {...register('password', { required: true })}
@@ -118,13 +114,7 @@ const SignUpForm = () => {
             placeholder='닉네임'
             className='flex-1'
           />
-          <button
-            onClick={() => {
-              handleDupCheckNickname(nickname)
-            }}
-          >
-            중복 확인
-          </button>
+          <button onClick={handleDupCheckNickname}>중복 확인</button>
         </div>
       </form>
     </fieldset>

--- a/src/components/sign-up/SignUpForm.jsx
+++ b/src/components/sign-up/SignUpForm.jsx
@@ -1,4 +1,6 @@
+import nicknameDupCheck from '@/apis/authentication/nicknameDupCheck'
 import signUpApi from '@/apis/authentication/signUpApi'
+import usernameDupCheck from '@/apis/authentication/usernameDupCheck'
 import { useState } from 'react'
 import { useForm } from 'react-hook-form'
 
@@ -37,6 +39,30 @@ const SignUpForm = () => {
   }
 
   const selectedDomain = watch('domain')
+  const username = watch('username')
+  const nickname = watch('nickname')
+
+  const handleDupCheckUsername = async (usernane) => {
+    try {
+      const result = await usernameDupCheck(username)
+      alert(result.message)
+      console.log(result)
+    } catch (err) {
+      alert(err.message)
+      console.error('아이디 중복 확인 실패:', err)
+    }
+  }
+
+  const handleDupCheckNickname = async (nickname) => {
+    try {
+      const result = await nicknameDupCheck(nickname)
+      alert(result.message)
+      console.log(result)
+    } catch (err) {
+      alert(err.message)
+      console.error(`닉네임 중복 확인 에러:`, err)
+    }
+  }
 
   return (
     <fieldset className='border p-5'>
@@ -45,7 +71,20 @@ const SignUpForm = () => {
         onSubmit={handleSubmit(onSubmit)}
         className='flex flex-col gap-2 p-5'
       >
-        <input {...register('username', { required: true })} placeholder='ID' />
+        <div className='flex items-center gap-2'>
+          <input
+            {...register('username', { required: true })}
+            placeholder='ID'
+            className='flex-1'
+          />
+          <button
+            onClick={() => {
+              handleDupCheckUsername(username)
+            }}
+          >
+            중복 확인
+          </button>
+        </div>
         <input
           {...register('password', { required: true })}
           placeholder='Password'
@@ -73,13 +112,20 @@ const SignUpForm = () => {
             <option value='daum.net'>daum.net</option>
           </select>
         </div>
-        <input
-          {...register('nickname', { required: true })}
-          placeholder='닉네임'
-        />
-        <button type='submit' className='rounded-2xl border p-2'>
-          회원가입
-        </button>
+        <div className='flex items-center gap-2'>
+          <input
+            {...register('nickname', { required: true })}
+            placeholder='닉네임'
+            className='flex-1'
+          />
+          <button
+            onClick={() => {
+              handleDupCheckNickname(nickname)
+            }}
+          >
+            중복 확인
+          </button>
+        </div>
       </form>
     </fieldset>
   )


### PR DESCRIPTION
## 구현 배경
- [IL-98](https://ilmansa.atlassian.net/browse/IL-98?atlOrigin=eyJpIjoiYjg0NjhmYTMyZDhiNDVlZTkzM2E4ZjQ4MjM2MzUwNGMiLCJwIjoiaiJ9)

## 작업 사항
- **아이디 중복 확인 API 구현(d2e1d3336e2add3d13356915b61ca78f3fe7f599)**
- **닉네임 중복 확인 API 구현(8dd2239c595006d93ee701311b5f4ee5222b047d)**
- **회원가입 양식에 중복 확인 적용(8d531dd58f433e9b1ec32dea3bdc0e059becd22d)**
- **오타 수정 및 불필요 코드 삭제(44a8af80d268acf69e994d377678650ef308cf42)**

## 추가 논의
-  현재는 일반 회원가입에만 중복 확인 로직을 구현했습니다.
- OAuth 게스트 로그인 시 닉네임 중복 확인에서 해당 API 가져다 쓰시면 될 것 같습니다.


[IL-98]: https://ilmansa.atlassian.net/browse/IL-98?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ