### PR TITLE
Feature(IL-89): Access Token 재발급

### DIFF
--- a/src/apis/api.jsx
+++ b/src/apis/api.jsx
@@ -1,5 +1,7 @@
 import { baseUrl } from '@/config/Env'
 import axios from 'axios'
+import reissueAccessToken from './authentication/reissueAccessToken'
+import { callLogout } from './authentication/logoutHandler'
 
 /**axios 공통 API 인스턴스 */
 const api = axios.create({
@@ -16,12 +18,35 @@ export const setUpInterceptors = () => {
   api.interceptors.request.use(
     (config) => {
       const accessToken = sessionStorage.getItem('accessToken')
-      if (accessToken) {
+      if (accessToken && !config.url.includes('/auth/reissue')) {
         config.headers.Authorization = `Bearer ${accessToken}`
       }
       return config
     },
     (error) => {
+      return Promise.reject(error)
+    },
+  )
+
+  /**토큰 만료 시 refresh Token을 이용하여 Access Token 재발급 */
+  api.interceptors.response.use(
+    (response) => response,
+    async (error) => {
+      const originalRequest = error.config
+      if (error.response?.status === 401 && !originalRequest._retry) {
+        originalRequest._retry = true
+        try {
+          const result = await reissueAccessToken()
+          const newAccessToken = result.data.accessToken
+          sessionStorage.setItem('accessToken', newAccessToken)
+          originalRequest.headers.Authorization = `Bearer ${newAccessToken}`
+          console.log('토큰 만료로 인해 재발급합니다..')
+          return api(originalRequest)
+        } catch (err) {
+          console.error('토큰 재발급 실패: ', err)
+          callLogout()
+        }
+      }
       return Promise.reject(error)
     },
   )

--- a/src/apis/authentication/logoutHandler.jsx
+++ b/src/apis/authentication/logoutHandler.jsx
@@ -1,0 +1,16 @@
+/**logout 함수가 삽입될 변수 */
+let logoutCallback = null
+
+/**logoutCallback 변수에 logout 함수 담기 */
+export const setLogoutCallback = (callback) => {
+  logoutCallback = callback
+}
+
+/**logout 실행, logout이 로드되지 않았으면 경고 출력 */
+export const callLogout = () => {
+  if (typeof logoutCallback === 'function') {
+    logoutCallback()
+  } else {
+    console.warn('로그아웃이 아직 설정되지 않았습니다.')
+  }
+}

--- a/src/apis/authentication/reissueAccessToken.jsx
+++ b/src/apis/authentication/reissueAccessToken.jsx
@@ -1,0 +1,23 @@
+import api from '../api'
+
+/**Access Token 재발급 API */
+const reissueAccessToken = async () => {
+  try {
+    const response = await api.get('/auth/reissue', {
+      headers: { device: 'WEB' },
+    })
+    return response.data
+  } catch (err) {
+    if (err.response?.data?.message) {
+      throw new Error(err.response.data.message)
+    } else if (err.response) {
+      throw new Error(`오류 발생 (status: ${err.response.status})`)
+    } else if (err.request) {
+      throw new Error('서버로부터 응답이 없습니다.')
+    } else {
+      throw new Error('요청 중 알 수 없는 오류가 발생했습니다.')
+    }
+  }
+}
+
+export default reissueAccessToken

--- a/src/components/sign-in/SignInForm.jsx
+++ b/src/components/sign-in/SignInForm.jsx
@@ -2,9 +2,11 @@ import regularSignInApi from '@/apis/authentication/regularSignInApi'
 import { useForm } from 'react-hook-form'
 import SignInButton from './SignInButton'
 import useAuth from '@/hooks/useAuth'
+import { useNavigate } from 'react-router-dom'
 
 const SignInForm = () => {
   const { login } = useAuth()
+  const navigate = useNavigate()
 
   const {
     register,
@@ -28,6 +30,7 @@ const SignInForm = () => {
       alert('로그인에 성공했습니다!')
       login({ token: result.data.accessToken })
       console.log('로그인 성공: ', result)
+      navigate('/')
     } catch (err) {
       alert(`로그인 실패: ${err.message}`)
       console.error('로그인 에러: ', err)

--- a/src/contexts/AuthProvider.jsx
+++ b/src/contexts/AuthProvider.jsx
@@ -7,6 +7,7 @@ import {
   parseNicknameFromToken,
   saveAuthToStorage,
 } from './AuthUtil'
+import { setLogoutCallback } from '@/apis/authentication/logoutHandler'
 
 /**React Context API를 이용한 전역 관리 컴포넌트 */
 const AuthProvider = ({ children }) => {
@@ -42,6 +43,11 @@ const AuthProvider = ({ children }) => {
     clearStorage()
     window.location.href = '/'
   }, [])
+
+  /**AuthProvier가 로드되면서 logout 함수를 logoutCallback 변수로 삽입 */
+  useEffect(() => {
+    setLogoutCallback(logout)
+  }, [logout])
 
   /**웹 전체에 전역으로 공급 */
   const value = useMemo(


### PR DESCRIPTION
## 구현 배경
- [IL-89](https://ilmansa.atlassian.net/browse/IL-89)
- Access Token 만료 시 Refresh Token을 사용하여 Access Token을 재발급 필요

## 작업 사항
- **토큰 재발급 API 구현(d929421e9d4190979f5f15dcd9ff2930979257cc)**
- **자동 토큰 재발급 구현(2fc8e8974dab137a76ca530d4d2cb4fc8299cb7e)**
  - 응답 인터셉터를 사용하여 `401 Error(토큰 만료)` 발생 시에 토큰 재발급 요청을 보내도록 구현
- **토큰 재발급 오류 시 자동 로그아웃(de6a85ce831a09c34f7a7bab44ad7d75bc7792a2)**
  - 인터셉터 내에서 `useAuth` 커스텀 훅을 호출할 수 없어 전역 로그아웃 핸들러를 사용하여 비동기 호출
- **로그인 성공 시 메인페이지로 이동 기능 추가(e85873dc6679c2f15a9b2462b135f86c765d9543)**


[IL-89]: https://ilmansa.atlassian.net/browse/IL-89?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ