### PR TITLE
Feature(IL-144): OAuth 로그인 시 닉네임 외 개인정보 마스킹

### DIFF
--- a/src/components/sign-in/KakaoRedirect.jsx
+++ b/src/components/sign-in/KakaoRedirect.jsx
@@ -9,24 +9,26 @@ const KakaoRedirect = () => {
   const { login } = useAuth()
 
   useEffect(() => {
-    const queryPrams = new URLSearchParams(location.search)
-    const code = queryPrams.get('code')
+    const queryParams = new URLSearchParams(location.search)
+    const code = queryParams.get('code')
 
     if (code) {
       fetchKakaoAccessToken(code)
     }
   }, [location])
 
-  /**카카오 소셜 로그인 호출 */
+  /** 카카오 소셜 로그인 호출 */
   const fetchKakaoAccessToken = async (code) => {
     try {
       const response = await oauthSignInApi('KAKAO', code)
       login({ token: response.data.token.accessToken })
+      sessionStorage.setItem('fromOAuth', 'true')
       navigate('/')
     } catch (error) {
       console.error('카카오 로그인 중 오류 발생:', error.message)
     }
   }
+  return null
 }
 
 export default KakaoRedirect

--- a/src/components/sign-in/NaverRedirect.jsx
+++ b/src/components/sign-in/NaverRedirect.jsx
@@ -9,24 +9,27 @@ const NaverRedirect = () => {
   const { login } = useAuth()
 
   useEffect(() => {
-    const queryPrams = new URLSearchParams(location.search)
-    const code = queryPrams.get('code')
+    const queryParams = new URLSearchParams(location.search)
+    const code = queryParams.get('code')
 
     if (code) {
       fetchNaverAccessToken(code)
     }
   }, [location])
 
-  /**네이버 소셜 로그인 호출 */
+  /** 네이버 소셜 로그인 호출 */
   const fetchNaverAccessToken = async (code) => {
     try {
       const response = await oauthSignInApi('NAVER', code)
       login({ token: response.data.token.accessToken })
+      sessionStorage.setItem('fromOAuth', 'true')
       navigate('/')
     } catch (error) {
       console.error('네이버 로그인 중 오류 발생:', error.message)
     }
   }
+
+  return null
 }
 
 export default NaverRedirect

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -15,6 +15,7 @@ const Home = () => {
   const handleSignOut = async () => {
     try {
       const result = await signOutApi()
+      sessionStorage.removeItem('fromOAuth')
       logout()
     } catch (error) {
       console.error('로그아웃 중 오류 발생: ', error.message)

--- a/src/pages/MyPage.jsx
+++ b/src/pages/MyPage.jsx
@@ -3,6 +3,7 @@ import userInfoApi from '@/apis/users/userInfoApi'
 import updatePasswordApi from '@/apis/users/updatePasswordApi'
 import { useEffect, useState } from 'react'
 import useAuth from '@/hooks/useAuth'
+import { useNavigate } from 'react-router-dom'
 
 const MyPage = () => {
   const [userInfo, setUserInfo] = useState([])
@@ -12,12 +13,13 @@ const MyPage = () => {
   const [isNicknameInputOpen, setIsNicknameInputOpen] = useState(false)
   const [isPasswordInputOpen, setIsPasswordInputOpen] = useState(false)
   const { logout } = useAuth()
+  const navigate = useNavigate()
+  const isFromOAuth = sessionStorage.getItem('fromOAuth') === 'true'
 
   /**회원 정보 조회 API 호출 */
   const fetchUserInfo = async () => {
     try {
       const result = await userInfoApi()
-
       setUserInfo(result.data)
     } catch (err) {
       console.error('회원 정보 조회 에러: ', err)
@@ -74,43 +76,48 @@ const MyPage = () => {
   return (
     <div className='flex h-screen w-screen flex-col items-center justify-center gap-2'>
       <p>닉네임: {userInfo.nickname}</p>
-      <button onClick={toggleNicknameInput}>닉네임 변경</button>
-      {isNicknameInputOpen && (
-        <form onSubmit={updateNickname} className='flex gap-2'>
-          <input
-            placeholder='새로운 닉네임을 입력해주세요'
-            value={newNickname}
-            onChange={(e) => setNewNickname(e.target.value)}
-            className='w-75'
-          />
-          <button type='submit'>확인</button>
-        </form>
-      )}
 
-      <p>이메일: {userInfo.email}</p>
+      {!isFromOAuth && (
+        <>
+          <button onClick={toggleNicknameInput}>닉네임 변경</button>
+          {isNicknameInputOpen && (
+            <form onSubmit={updateNickname} className='flex gap-2'>
+              <input
+                placeholder='새로운 닉네임을 입력해주세요'
+                value={newNickname}
+                onChange={(e) => setNewNickname(e.target.value)}
+                className='w-75'
+              />
+              <button type='submit'>확인</button>
+            </form>
+          )}
 
-      <button onClick={togglePasswordInput}>비밀번호 변경</button>
-      {isPasswordInputOpen && (
-        <form
-          onSubmit={updatePassword}
-          className='flex flex-col items-center justify-center gap-2'
-        >
-          <input
-            placeholder='기존 비밀번호를 입력해주세요'
-            value={originalPassword}
-            onChange={(e) => setOriginalPassword(e.target.value)}
-            className='w-75'
-            type='password'
-          />
-          <input
-            placeholder='새로운 비밀번호를 입력해주세요'
-            value={newPassword}
-            onChange={(e) => setNewPassword(e.target.value)}
-            className='w-75'
-            type='password'
-          />
-          <button type='submit'>변경하기</button>
-        </form>
+          <p>이메일: {userInfo.email}</p>
+
+          <button onClick={togglePasswordInput}>비밀번호 변경</button>
+          {isPasswordInputOpen && (
+            <form
+              onSubmit={updatePassword}
+              className='flex flex-col items-center justify-center gap-2'
+            >
+              <input
+                placeholder='기존 비밀번호를 입력해주세요'
+                value={originalPassword}
+                onChange={(e) => setOriginalPassword(e.target.value)}
+                className='w-75'
+                type='password'
+              />
+              <input
+                placeholder='새로운 비밀번호를 입력해주세요'
+                value={newPassword}
+                onChange={(e) => setNewPassword(e.target.value)}
+                className='w-75'
+                type='password'
+              />
+              <button type='submit'>변경하기</button>
+            </form>
+          )}
+        </>
       )}
     </div>
   )

--- a/src/pages/MyPage.jsx
+++ b/src/pages/MyPage.jsx
@@ -76,7 +76,9 @@ const MyPage = () => {
   return (
     <div className='flex h-screen w-screen flex-col items-center justify-center gap-2'>
       <p>닉네임: {userInfo.nickname}</p>
-
+      {isFromOAuth && (
+        <button onClick={() => navigate('/')}>홈으로 이동</button>
+      )}
       {!isFromOAuth && (
         <>
           <button onClick={toggleNicknameInput}>닉네임 변경</button>


### PR DESCRIPTION
## 구현 배경

- [IL-144](https://ilmansa.atlassian.net/browse/IL-144) 참고
- 소셜 로그인 시 닉네임 외의 정보 수정은 불필요하므로 숨기고자 함

## 작업 사항

- OAuth 로그인 시 fromOAuth의 상태 값을 true로 세션스토리지에 저장(a79af3154eb74bdb73a98218e01f1f2f9790bf51)
- fromOAuth가 true일 경우 닉네임 외 정보, 버튼은 숨기기(4047e88fae594bc9e65952bdffa22f5f6555c41f)
- 로그아웃 시 fromOAuth 상태 제거(fff870f4a85a18424d150075cd890178ae93658b)
- OAuth 로그인 후 마이페이지 이동 시 `홈으로이동` 버튼 추가

## 추가 논의

- 그냥 state로 저장 시도했으나 이전 페이지로 갔다가 다시 마이페이지로 돌아왔을 때 state 적용이 원활하지 않아서 세션 스토리지에 저장하였음


[IL-144]: https://ilmansa.atlassian.net/browse/IL-144?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ