### PR TITLE
Feature(IL-144): 로그인타입에 따른 UI 컴포넌트 조건부 렌더링

### DIFF
--- a/src/contexts/AuthProvider.jsx
+++ b/src/contexts/AuthProvider.jsx
@@ -4,7 +4,7 @@ import {
   clearStorage,
   loadTokenFromStorage,
   loadUserFromStorage,
-  parseNicknameFromToken,
+  parsingFromToken,
   saveAuthToStorage,
 } from './AuthUtil'
 import { setLogoutCallback } from '@/apis/authentication/logoutHandler'
@@ -21,19 +21,20 @@ const AuthProvider = ({ children }) => {
     if (storedUser) setUser(storedUser)
     if (storedToken) {
       setAccessToken(storedToken)
-      const nickname = parseNicknameFromToken(storedToken)
-      if (nickname) {
-        setUser((prev) => ({ ...prev, nickname }))
+      const { nickname, loginType } = parsingFromToken(storedToken)
+      if (nickname || loginType) {
+        setUser((prev) => ({ ...prev, nickname, loginType }))
       }
     }
   }, [])
 
   /**로그인 시 세션 스토리지에 사용자 정보 및 Access Token 저장 */
   const login = useCallback(({ user, token }) => {
-    const nickname = parseNicknameFromToken(token)
-    setUser({ ...user, nickname })
+    const { nickname, loginType } = parsingFromToken(token)
+    const userWithTokenInfo = { ...user, nickname, loginType }
+    setUser(userWithTokenInfo)
     setAccessToken(token)
-    saveAuthToStorage({ ...user, nickname }, token)
+    saveAuthToStorage(userWithTokenInfo, token)
   }, [])
 
   /**로그아웃 시 세션 스토리지 및 user, accessToken 초기화 */

--- a/src/contexts/AuthUtil.jsx
+++ b/src/contexts/AuthUtil.jsx
@@ -38,10 +38,12 @@ export const decodeToken = (token) => {
   }
 }
 
-/**디코딩 된 Access Token에서 닉네임 가져오기 */
-export const parseNicknameFromToken = (token) => {
+/**디코딩 된 Access Token에서 닉네임 및 로그인타입 가져오기 */
+export const parsingFromToken = (token) => {
   const decoded = decodeToken(token)
-  return decoded ? decoded.nickname : null
+  if (!decoded) return { nickname: null, loginType: null }
+  const { nickname, loginType } = decoded
+  return { nickname, loginType }
 }
 
 /**사용자 정보와 Access Token을 세션 스토리지에 저장 */

--- a/src/pages/MyPage.jsx
+++ b/src/pages/MyPage.jsx
@@ -11,7 +11,8 @@ const MyPage = () => {
   const [newPassword, setNewPassword] = useState('')
   const [isNicknameInputOpen, setIsNicknameInputOpen] = useState(false)
   const [isPasswordInputOpen, setIsPasswordInputOpen] = useState(false)
-  const { logout } = useAuth()
+  const { logout, user } = useAuth()
+  const loginType = user?.loginType
 
   /**회원 정보 조회 API 호출 */
   const fetchUserInfo = async () => {
@@ -74,43 +75,45 @@ const MyPage = () => {
   return (
     <div className='flex h-screen w-screen flex-col items-center justify-center gap-2'>
       <p>닉네임: {userInfo.nickname}</p>
-      <button onClick={toggleNicknameInput}>닉네임 변경</button>
-      {isNicknameInputOpen && (
-        <form onSubmit={updateNickname} className='flex gap-2'>
-          <input
-            placeholder='새로운 닉네임을 입력해주세요'
-            value={newNickname}
-            onChange={(e) => setNewNickname(e.target.value)}
-            className='w-75'
-          />
-          <button type='submit'>확인</button>
-        </form>
-      )}
-
-      <p>이메일: {userInfo.email}</p>
-
-      <button onClick={togglePasswordInput}>비밀번호 변경</button>
-      {isPasswordInputOpen && (
-        <form
-          onSubmit={updatePassword}
-          className='flex flex-col items-center justify-center gap-2'
-        >
-          <input
-            placeholder='기존 비밀번호를 입력해주세요'
-            value={originalPassword}
-            onChange={(e) => setOriginalPassword(e.target.value)}
-            className='w-75'
-            type='password'
-          />
-          <input
-            placeholder='새로운 비밀번호를 입력해주세요'
-            value={newPassword}
-            onChange={(e) => setNewPassword(e.target.value)}
-            className='w-75'
-            type='password'
-          />
-          <button type='submit'>변경하기</button>
-        </form>
+      {loginType !== 'SOCIAL' && (
+        <>
+          <button onClick={toggleNicknameInput}>닉네임 변경</button>
+          {isNicknameInputOpen && (
+            <form onSubmit={updateNickname} className='flex gap-2'>
+              <input
+                placeholder='새로운 닉네임을 입력해주세요'
+                value={newNickname}
+                onChange={(e) => setNewNickname(e.target.value)}
+                className='w-75'
+              />
+              <button type='submit'>확인</button>
+            </form>
+          )}
+          <p>이메일: {userInfo.email}</p>
+          <button onClick={togglePasswordInput}>비밀번호 변경</button>
+          {isPasswordInputOpen && (
+            <form
+              onSubmit={updatePassword}
+              className='flex flex-col items-center justify-center gap-2'
+            >
+              <input
+                placeholder='기존 비밀번호를 입력해주세요'
+                value={originalPassword}
+                onChange={(e) => setOriginalPassword(e.target.value)}
+                className='w-75'
+                type='password'
+              />
+              <input
+                placeholder='새로운 비밀번호를 입력해주세요'
+                value={newPassword}
+                onChange={(e) => setNewPassword(e.target.value)}
+                className='w-75'
+                type='password'
+              />
+              <button type='submit'>변경하기</button>
+            </form>
+          )}
+        </>
       )}
     </div>
   )

--- a/src/pages/MyPage.jsx
+++ b/src/pages/MyPage.jsx
@@ -77,11 +77,7 @@ const MyPage = () => {
   return (
     <div className='flex h-screen w-screen flex-col items-center justify-center gap-2'>
       <p>닉네임: {userInfo.nickname}</p>
-      {loginType == 'SOCIAL' && (
-        <button onClick={() => navigate('/')}>홈으로 이동</button>
-      )}
       <button onClick={toggleNicknameInput}>닉네임 변경</button>
-
       {isNicknameInputOpen && (
         <form onSubmit={updateNickname} className='flex gap-2'>
           <input
@@ -121,6 +117,7 @@ const MyPage = () => {
           )}
         </>
       )}
+      <button onClick={() => navigate('/')}>홈으로 이동</button>
     </div>
   )
 }

--- a/src/pages/MyPage.jsx
+++ b/src/pages/MyPage.jsx
@@ -3,6 +3,7 @@ import userInfoApi from '@/apis/users/userInfoApi'
 import updatePasswordApi from '@/apis/users/updatePasswordApi'
 import { useEffect, useState } from 'react'
 import useAuth from '@/hooks/useAuth'
+import { useNavigate } from 'react-router-dom'
 
 const MyPage = () => {
   const [userInfo, setUserInfo] = useState([])
@@ -13,6 +14,7 @@ const MyPage = () => {
   const [isPasswordInputOpen, setIsPasswordInputOpen] = useState(false)
   const { logout, user } = useAuth()
   const loginType = user?.loginType
+  const navigate = useNavigate()
 
   /**회원 정보 조회 API 호출 */
   const fetchUserInfo = async () => {
@@ -75,20 +77,24 @@ const MyPage = () => {
   return (
     <div className='flex h-screen w-screen flex-col items-center justify-center gap-2'>
       <p>닉네임: {userInfo.nickname}</p>
+      {loginType == 'SOCIAL' && (
+        <button onClick={() => navigate('/')}>홈으로 이동</button>
+      )}
+      <button onClick={toggleNicknameInput}>닉네임 변경</button>
+
+      {isNicknameInputOpen && (
+        <form onSubmit={updateNickname} className='flex gap-2'>
+          <input
+            placeholder='새로운 닉네임을 입력해주세요'
+            value={newNickname}
+            onChange={(e) => setNewNickname(e.target.value)}
+            className='w-75'
+          />
+          <button type='submit'>확인</button>
+        </form>
+      )}
       {loginType !== 'SOCIAL' && (
         <>
-          <button onClick={toggleNicknameInput}>닉네임 변경</button>
-          {isNicknameInputOpen && (
-            <form onSubmit={updateNickname} className='flex gap-2'>
-              <input
-                placeholder='새로운 닉네임을 입력해주세요'
-                value={newNickname}
-                onChange={(e) => setNewNickname(e.target.value)}
-                className='w-75'
-              />
-              <button type='submit'>확인</button>
-            </form>
-          )}
           <p>이메일: {userInfo.email}</p>
           <button onClick={togglePasswordInput}>비밀번호 변경</button>
           {isPasswordInputOpen && (


### PR DESCRIPTION
## 구현 배경

- [IL-144](https://ilmansa.atlassian.net/browse/IL-144) 참고
- `SOCIAL` 타입 로그인 시 닉네임 외 **개인정보** 및 **정보수정 버튼**을 숨기고자 함

## 작업 사항

- 디코딩 된 토큰에서 `loginType` 추출(2b73f3b7561d02da9be98d138060b741aaf53d0b)
- **sessionStorage**에 `loginType` 저장(3f433773ab56f1b5e87f12e5a12c642db6835690)
- loginType이 `SOCIAL`일 경우 닉네임 외 정보 숨기기(f7e1cdc17b1cd9fc1de2ef24683f31f9a95af170)

## 추가 논의

- [이전 pr](https://github.com/Team-Ilmansa/yeogiga-web/pull/32)의 @gugitgugit 님의 코드 피드백 반영하여 로직 변경


[IL-144]: https://ilmansa.atlassian.net/browse/IL-144?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ