### PR TITLE
Feature(IL-183): W2M 캘린더에서 나의 등록된 일정 조회

### DIFF
--- a/src/apis/calendar/readMyCalendarApi.jsx
+++ b/src/apis/calendar/readMyCalendarApi.jsx
@@ -1,0 +1,21 @@
+import api from '@/apis/api'
+
+/**나의 W2M 캘린더 조회 API */
+const readMyCalendarApi = async (tripId) => {
+  try {
+    const response = await api.get(`trip/${tripId}/calendars/me`)
+    return response.data
+  } catch (err) {
+    if (err.response?.data?.message) {
+      throw new Error(err.response.data.message)
+    } else if (err.response) {
+      throw new Error(`오류 발생 (status: ${err.response.status})`)
+    } else if (err.request) {
+      throw new Error('서버로부터 응답이 없습니다.')
+    } else {
+      throw new Error('요청 중 알 수 없는 오류가 발생했습니다.')
+    }
+  }
+}
+
+export default readMyCalendarApi

--- a/src/components/trip/TripCalendar.jsx
+++ b/src/components/trip/TripCalendar.jsx
@@ -4,10 +4,18 @@ import 'react-calendar/dist/Calendar.css'
 import './TripCalendar.css'
 import createCalendarApi from '@/apis/calendar/createCalendarApi'
 import readCalendarApi from '@/apis/calendar/readCalendarApi'
+import readMyCalendarApi from '@/apis/calendar/readMyCalendarApi'
 
 const TripCalendar = ({ tripInfo }) => {
+  /**팀원 전체 일정 */
   const [availabilities, setAvailabilities] = useState([])
+  /**등록 중인 일정 */
   const [availableDates, setAvailableDates] = useState([])
+  /**등록된 나의 일정 */
+  const [myAvailableDates, setMyAvailableDates] = useState([])
+  /**W2M 등록 여부 */
+  const [isRegistred, setIsRegistred] = useState(false)
+  /**W2M 등록 or 수정 중인 상태 */
   const [isEditing, setIsEditing] = useState(true)
 
   useEffect(() => {
@@ -24,12 +32,32 @@ const TripCalendar = ({ tripInfo }) => {
       }
     }
 
+    /**나의 W2M 캘린더 조회 API 호출 */
+    const fetchMyCalendar = async () => {
+      try {
+        const result = await readMyCalendarApi(tripInfo.tripId)
+        setMyAvailableDates(result.data?.availableDates)
+        if (result.data) {
+          setIsRegistred(true)
+        }
+      } catch (err) {
+        alert(err.message)
+      }
+    }
+
     fetchCalendar()
+    fetchMyCalendar()
   }, [])
 
-  /**팀원 전체 캘린더 or 본인 일정 캘린더 */
-  const toggleEditingCalendar = () => {
-    setIsEditing((prev) => !prev)
+  /**등록 or 수정용 캘린더 열기 */
+  const openEditingCalendar = () => {
+    setIsEditing(true)
+    setAvailableDates(myAvailableDates)
+  }
+
+  /**등록 or 수정용 캘린더 닫기 */
+  const closeEditingCalendar = () => {
+    setIsEditing(false)
   }
 
   const handleDateClick = (date, event) => {
@@ -111,7 +139,7 @@ const TripCalendar = ({ tripInfo }) => {
             }}
           />
           <div className='flex'>
-            <button onClick={toggleEditingCalendar}>취소</button>
+            <button onClick={closeEditingCalendar}>취소</button>
             <button onClick={createCalendar}>일정 등록</button>
           </div>
         </div>
@@ -139,7 +167,7 @@ const TripCalendar = ({ tripInfo }) => {
               return null
             }}
           />
-          <button onClick={toggleEditingCalendar}>일정 등록하기</button>
+          <button onClick={openEditingCalendar}>일정 등록하기</button>
         </>
       )}
     </div>


### PR DESCRIPTION
## 구현 배경
- [IL-183](https://ilmansa.atlassian.net/browse/IL-183)
- 등록된 일정을 수정할 시 자동으로 기존에 등록된 일정을 불러오기 위함

## 작업 사항
- **나의 캘린더 조회 API 구현(c279bfc00f4c7a851c096e8529b06be45f9d2c18)**
- **수정용 캘린더와 연결(6533a10b9307e457f3dc25d147696ac248058c32)**

## 추가 논의
- 최초 등록을 하였는지 확인하기 위해 `isRegistred` 상태를 사용하였습니다.
- 수정용 캘린더 출력 시에 현재 등록되어있는 나의 일정을 출력합니다.
![chrome-capture-2025-6-10](https://github.com/user-attachments/assets/6adc82a9-fd47-4354-a987-3c5c40e340ad)


[IL-183]: https://ilmansa.atlassian.net/browse/IL-183?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ