### PR TITLE
Feature(IL-186): 멤버 더 보기 화면 구현

### DIFF
--- a/src/components/trip/TripInfo.jsx
+++ b/src/components/trip/TripInfo.jsx
@@ -21,6 +21,7 @@ const TripInfo = ({ tripInfo }) => {
   const [newStartTime, setNewStartTime] = useState('')
   const [newEndTime, setNewEndTime] = useState('')
   const [isUpdateTimeInputOpen, setIsUpdateTimeInputOpen] = useState(false)
+  const [isMembersOpen, setIsMembersOpen] = useState(false)
 
   const navigate = useNavigate()
 
@@ -60,6 +61,11 @@ const TripInfo = ({ tripInfo }) => {
   const toggleUpdateTimeInput = () => {
     setIsUpdateTimeInputOpen((prev) => !prev)
     setNewTime('')
+  }
+
+  /**여행 멤버 더 보기 화면 출력 상태 토글 */
+  const toggleViewMembers = () => {
+    setIsMembersOpen((prev) => !prev)
   }
 
   /**여행 시간 변경 토클 시 날짜 초기 세팅 */
@@ -173,27 +179,48 @@ const TripInfo = ({ tripInfo }) => {
 
             <fieldset className='rounded-2xl border p-4'>
               <legend className='p-2'>여행 멤버</legend>
-              <ul>
-                {tripInfo.members.map((member) => (
+              <ul className='flex items-center gap-2'>
+                {tripInfo.members.slice(0, 3).map((member) => (
                   <li key={member.userId}>
-                    {member.nickname}
-                    {member.imageUrl ? (
-                      <img
-                        src={member.imageUrl}
-                        alt={member.nickname}
-                        width='30'
-                      />
-                    ) : (
-                      <div>(이미지 없음)</div>
-                    )}
+                    <img
+                      src={member.imageUrl || '/images/default_profile.png'}
+                      alt='프로필'
+                      className='h-6 w-6 rounded-full object-cover'
+                    />
                   </li>
                 ))}
+                <button onClick={toggleViewMembers}>...</button>
               </ul>
             </fieldset>
           </fieldset>
         </div>
       ) : (
         <p>여행 정보를 불러오는 중...</p>
+      )}
+
+      {isMembersOpen && (
+        <div
+          className='fixed inset-0 z-50 flex items-center justify-center bg-black/40'
+          onClick={toggleViewMembers}
+        >
+          <div
+            className='rounded-3xl bg-white p-20 text-3xl shadow'
+            onClick={(e) => e.stopPropagation()}
+          >
+            <ul className='flex flex-col items-baseline gap-5'>
+              {tripInfo.members.slice(0, 3).map((member) => (
+                <li key={member.userId} className='flex items-center gap-2'>
+                  <img
+                    src={member.imageUrl || '/images/default_profile.png'}
+                    alt='프로필'
+                    className='h-15 w-15 rounded-full object-cover'
+                  />
+                  <span>{member.nickname}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        </div>
       )}
     </div>
   )

--- a/src/components/trip/TripInfo.jsx
+++ b/src/components/trip/TripInfo.jsx
@@ -208,7 +208,7 @@ const TripInfo = ({ tripInfo }) => {
             onClick={(e) => e.stopPropagation()}
           >
             <ul className='flex flex-col items-baseline gap-5'>
-              {tripInfo.members.slice(0, 3).map((member) => (
+              {tripInfo.members.map((member) => (
                 <li key={member.userId} className='flex items-center gap-2'>
                   <img
                     src={member.imageUrl || '/images/default_profile.png'}


### PR DESCRIPTION
## 구현 배경
- [IL-186](https://ilmansa.atlassian.net/browse/IL-186)
- 여행 정보 화면에서 프로필 사진만 출력하고, `...` 버튼 클릭 시 멤버의 자세한 정보를 보여주기 위함

## 작업 사항
- **멤버 더 보기 화면 구현**(5756e32386964c214abf1ddac62ad83bad0d7ab3)
- **인원 제한 해제**(50dbd832872e832ee2949595bb6d6be4baf5e7ac)
![스크린샷 2025-07-03 15 08 22](https://github.com/user-attachments/assets/31cf49c5-778f-4883-985f-15ccaaef44c4)
![스크린샷 2025-07-03 15 08 39](https://github.com/user-attachments/assets/03d23cc7-0262-4304-946c-ea9b1fac0192)
![스크린샷 2025-07-03 15 08 54](https://github.com/user-attachments/assets/1518b0b8-c3ed-4f82-9ba9-1f48a87f5cef)


## 추가 논의
- `여행 멤버 조회 API`를 통해 최초 구현 계획이었으나, `특정 여행 정보 조회 API`에서 동일한 정보를 제공하여 추가 API 연결 없이 구현하였습니다.

[IL-186]: https://ilmansa.atlassian.net/browse/IL-186?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ