### PR TITLE
Feature(IL-194): 여행 확정 UI 구현 및 API 연동

### DIFF
--- a/src/apis/trip/updateTripTimeApi.jsx
+++ b/src/apis/trip/updateTripTimeApi.jsx
@@ -1,9 +1,10 @@
 import api from '@/apis/api'
+import { prodBaseUrl } from '@/config/Env'
 
 /**여행 시간 수정 API */
 const updateTripTimeApi = async (tripId, body) => {
   try {
-    const response = await api.put(`trip/${tripId}/time`, body)
+    const response = await api.put(`${prodBaseUrl}trip/${tripId}/time`, body)
     return response.data
   } catch (err) {
     if (err.response?.data?.message) {

--- a/src/components/trip/TripCalendar.css
+++ b/src/components/trip/TripCalendar.css
@@ -131,3 +131,13 @@
 .available-10 {
   background-color: #9e33ff;
 }
+
+.confirmedDate {
+  border: 2px solid #4caf50;
+  background-color: rgba(76, 175, 80, 0.2) !important;
+}
+
+.leaderConfirmed {
+  background-color: #4caf50 !important;
+  color: white !important;
+}

--- a/src/components/trip/TripCalendar.css
+++ b/src/components/trip/TripCalendar.css
@@ -95,9 +95,23 @@
 }
 
 .continuousDate {
-  background: #e6e7ff;
-  color: #8287ff;
-  border-radius: 0px;
+  position: relative;
+  z-index: 1;
+  border-radius: 0px !important;
+  overflow: hidden;
+}
+
+/* 연한 배경을 위에 덮도록 */
+.continuousDate::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(130, 135, 255, 0.2);
+  z-index: 2;
+  pointer-events: none;
 }
 
 /* 인원 별(1 ~ 10) 캘린더 색 변경 */
@@ -132,12 +146,59 @@
   background-color: #9e33ff;
 }
 
-.confirmedDate {
-  border: 2px solid #4caf50;
-  background-color: rgba(76, 175, 80, 0.2) !important;
+/* 공통 확정 날짜 배경, 글자색, 강조 */
+.confirmed-start,
+.confirmed-end {
+  background-color: #8287ff !important;
+  color: black !important;
+  z-index: 2;
 }
 
-.leaderConfirmed {
-  background-color: #4caf50 !important;
+/* 시작 날짜만 왼쪽 둥글게 */
+.confirmed-start {
+  border-top-left-radius: 10px !important;
+  border-bottom-left-radius: 10px !important;
+}
+
+/* 끝 날짜만 오른쪽 둥글게 */
+.confirmed-end {
+  border-top-right-radius: 10px !important;
+  border-bottom-right-radius: 10px !important;
+}
+
+/* 시작 날짜의 오른쪽 둥글기 제거 */
+.confirmed-start.no-right-radius {
+  border-top-right-radius: 0 !important;
+  border-bottom-right-radius: 0 !important;
+}
+
+/* 끝 날짜의 왼쪽 둥글기 제거 */
+.confirmed-end.no-left-radius {
+  border-top-left-radius: 0 !important;
+  border-bottom-left-radius: 0 !important;
+}
+
+/* 확정된 가운데 날짜 */
+.confirmed-middle {
+  position: relative;
+  z-index: 1;
+  border-radius: 0 !important;
+}
+
+.confirmed-middle::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(130, 135, 255, 0.5);
+  z-index: 2;
+  pointer-events: none;
+}
+
+/* 방장이 확정하기 위해 선택한 날짜 */
+.selectedByLeader {
+  background-color: rgba(130, 135, 255, 0.9) !important;
   color: white !important;
 }

--- a/src/components/trip/TripCalendar.jsx
+++ b/src/components/trip/TripCalendar.jsx
@@ -21,7 +21,7 @@ const TripCalendar = ({ tripInfo }) => {
   const [isEditing, setIsEditing] = useState(true)
   /**팀원 전체 캘린더 클릭 시 날짜 선택 */
   const [selectedDates, setSelectedDates] = useState([])
-
+  /**여행 일정 확정 상태 */
   const [confirmedDates, setConfirmedDates] = useState([])
 
   useEffect(() => {

--- a/src/components/trip/TripCalendar.jsx
+++ b/src/components/trip/TripCalendar.jsx
@@ -6,6 +6,7 @@ import createCalendarApi from '@/apis/calendar/createCalendarApi'
 import readCalendarApi from '@/apis/calendar/readCalendarApi'
 import readMyCalendarApi from '@/apis/calendar/readMyCalendarApi'
 import updateMyCalendarApi from '@/apis/calendar/updateMyCalendarApi'
+import updateTripTimeApi from '@/apis/trip/updateTripTimeApi'
 
 const TripCalendar = ({ tripInfo }) => {
   /**팀원 전체 일정 */
@@ -18,6 +19,10 @@ const TripCalendar = ({ tripInfo }) => {
   const [isRegistred, setIsRegistred] = useState(false)
   /**W2M 등록 or 수정 중인 상태 */
   const [isEditing, setIsEditing] = useState(true)
+  /**팀원 전체 캘린더 클릭 시 날짜 선택 */
+  const [selectedDates, setSelectedDates] = useState([])
+
+  const [confirmedDates, setConfirmedDates] = useState([])
 
   useEffect(() => {
     /**W2M 캘린더 조회 API 호출 */
@@ -93,17 +98,88 @@ const TripCalendar = ({ tripInfo }) => {
     }
   }
 
-  /**W2M 캘린더 수정 API 호출 */
+  /**W2M 캘린더 수정 및 확정 API 호출 */
   const updateCalendar = async () => {
     const body = { availableDates: availableDates }
-    try {
-      const result = await updateMyCalendarApi(tripInfo.tripId, body)
-      alert('일정이 수정되었습니다')
-      window.location.reload()
-    } catch (err) {
-      alert(err.message)
+    if (window.confirm('날짜를 확정하시겠습니까?')) {
+      try {
+        const result = await updateMyCalendarApi(tripInfo.tripId, body)
+      } catch (err) {
+        alert(err.message)
+      }
     }
   }
+
+  /** 팀원 전체 캘린더 클릭 시 날짜 선택 */
+  const handleCalendarSelect = (date, event) => {
+    const target = event?.target?.closest('.react-calendar__tile')
+    if (target) target.blur()
+    const dateStr = date.toLocaleDateString('sv-SE')
+
+    setSelectedDates((prev) => {
+      const updated = prev.includes(dateStr)
+        ? prev.filter((d) => d !== dateStr)
+        : [...prev, dateStr]
+      return updated.sort()
+    })
+  }
+
+  /** 확정 버튼 클릭 시 동작 */
+  const handleConfirmDates = () => {
+    if (window.confirm('이 날짜들을 확정하시겠습니까?')) {
+      const updateTripCalendar = async () => {
+        const sorted = [...selectedDates].sort()
+        const newStartTime = sorted[0] + 'T00:00:00'
+        const newEndTime = sorted[sorted.length - 1] + 'T00:00:00'
+        try {
+          const result = await updateTripTimeApi(tripInfo.tripId, {
+            start: newStartTime,
+            end: newEndTime,
+          })
+          alert('날짜가 확정되었습니다!')
+          {
+            selectedDates.length > 0 &&
+              (() => {
+                const sorted = [...selectedDates].sort()
+                const start = new Date(sorted[0])
+                const end = new Date(sorted[sorted.length - 1])
+                const timeDiff = end.getTime() - start.getTime()
+                const dayCount =
+                  Math.floor(timeDiff / (1000 * 60 * 60 * 24)) + 1
+                const nightCount = dayCount - 1
+
+                return (
+                  <button type='button' onClick={handleConfirmDates}>
+                    {sorted[0]} - {sorted[sorted.length - 1]} / {nightCount}박{' '}
+                    {dayCount}일
+                  </button>
+                )
+              })()
+          }
+          console.log(result)
+          window.location.reload()
+        } catch (err) {
+          alert(err.message)
+        }
+      }
+      updateTripCalendar()
+    }
+  }
+
+  useEffect(() => {
+    if (tripInfo?.startedAt && tripInfo?.endedAt) {
+      const start = new Date(tripInfo.startedAt)
+      const end = new Date(tripInfo.endedAt)
+
+      const confirmed = []
+      const cur = new Date(start)
+      while (cur <= end) {
+        confirmed.push(cur.toLocaleDateString('sv-SE'))
+        cur.setDate(cur.getDate() + 1)
+      }
+      setConfirmedDates(confirmed)
+    }
+  }, [tripInfo.startedAt, tripInfo.endedAt])
 
   return (
     <div className='flex flex-col gap-5'>
@@ -154,19 +230,19 @@ const TripCalendar = ({ tripInfo }) => {
           <div className='flex'>
             <button onClick={closeEditingCalendar}>취소</button>
             {isRegistred ? (
-              <button onClick={updateCalendar}>일정 수정</button>
+              <button onClick={updateCalendar}>날짜 확정</button>
             ) : (
               <button onClick={createCalendar}>일정 등록</button>
             )}
           </div>
         </div>
       ) : (
-        /**팀원 전체 캘린더 */
+        /** 팀원 전체 캘린더 */
         <>
           <Calendar
             className='team-calendar'
             value={null}
-            /**CSS 적용을 위한 ClassName 변경 */
+            onClickDay={handleCalendarSelect}
             tileClassName={({ date, view }) => {
               if (view === 'month') {
                 const dateStr = date.toLocaleDateString('sv-SE')
@@ -179,15 +255,38 @@ const TripCalendar = ({ tripInfo }) => {
 
                 const count = countMap.get(dateStr) || 0
                 const level = Math.min(count, 10)
-                return `available-${level}`
+                const isSelected = selectedDates.includes(dateStr)
+                const isConfirmed =
+                  Array.isArray(confirmedDates) &&
+                  confirmedDates.includes(dateStr)
+                return `${isSelected ? 'confirmedDate ' : ''}${
+                  isConfirmed ? 'leaderConfirmed ' : ''
+                }available-${level}`
               }
               return null
             }}
           />
           <button onClick={openEditingCalendar}>
-            일정
-            {isRegistred ? ' 수정하기' : ' 등록하기'}
+            일정{isRegistred ? ' 수정하기' : ' 등록하기'}
           </button>
+
+          {/**선택한 날짜가 있으면 확정 버튼 보여주기*/}
+          {selectedDates.length > 0 &&
+            (() => {
+              const sorted = [...selectedDates].sort()
+              const start = new Date(sorted[0])
+              const end = new Date(sorted[sorted.length - 1])
+              const timeDiff = end.getTime() - start.getTime()
+              const dayCount = Math.floor(timeDiff / (1000 * 60 * 60 * 24)) + 1
+              const nightCount = dayCount - 1
+
+              return (
+                <button type='button' onClick={handleConfirmDates}>
+                  {sorted[0]} - {sorted[sorted.length - 1]} / {nightCount}박{' '}
+                  {dayCount}일
+                </button>
+              )
+            })()}
         </>
       )}
     </div>

--- a/src/components/trip/TripCalendar.jsx
+++ b/src/components/trip/TripCalendar.jsx
@@ -247,22 +247,79 @@ const TripCalendar = ({ tripInfo }) => {
             tileClassName={({ date, view }) => {
               if (view === 'month') {
                 const dateStr = date.toLocaleDateString('sv-SE')
+
+                /** 방장이 선택한 범위 */
+                let inSelectedRange = false
+                if (selectedDates.length > 0) {
+                  const sorted = [...selectedDates].sort()
+                  const rangeStart = new Date(sorted[0])
+                  const rangeEnd = new Date(sorted[sorted.length - 1])
+                  const current = new Date(dateStr)
+
+                  inSelectedRange = current >= rangeStart && current <= rangeEnd
+                }
+
+                /** 인원수 색상 계산 */
                 const countMap = new Map()
                 availabilities?.forEach(({ availableDates }) => {
                   availableDates.forEach((d) => {
                     countMap.set(d, (countMap.get(d) || 0) + 1)
                   })
                 })
-
                 const count = countMap.get(dateStr) || 0
                 const level = Math.min(count, 10)
-                const isSelected = selectedDates.includes(dateStr)
                 const isConfirmed =
                   Array.isArray(confirmedDates) &&
                   confirmedDates.includes(dateStr)
-                return `${isSelected ? 'confirmedDate ' : ''}${
-                  isConfirmed ? 'leaderConfirmed ' : ''
-                }available-${level}`
+
+                /** 각 이웃 날짜 */
+                const prevDate = new Date(date)
+                prevDate.setDate(date.getDate() - 1)
+                const nextDate = new Date(date)
+                nextDate.setDate(date.getDate() + 1)
+
+                const prevStr = prevDate.toLocaleDateString('sv-SE')
+                const nextStr = nextDate.toLocaleDateString('sv-SE')
+                const isPrevIn =
+                  selectedDates.length > 0 &&
+                  new Date(prevStr) >= new Date(selectedDates[0]) &&
+                  new Date(prevStr) <=
+                    new Date(selectedDates[selectedDates.length - 1])
+                const isNextIn =
+                  selectedDates.length > 0 &&
+                  new Date(nextStr) >= new Date(selectedDates[0]) &&
+                  new Date(nextStr) <=
+                    new Date(selectedDates[selectedDates.length - 1])
+
+                /** CSS용 class */
+                let classes = `available-${level}`
+                if (confirmedDates.includes(dateStr)) {
+                  const isPrev = confirmedDates.includes(prevStr)
+                  const isNext = confirmedDates.includes(nextStr)
+
+                  if (isPrev && isNext) {
+                    classes += ' confirmed-middle'
+                  } else if (!isPrev && isNext) {
+                    classes += ' confirmed-start'
+                    if (isNext) classes += ' no-right-radius'
+                  } else if (isPrev && !isNext) {
+                    classes += ' confirmed-end'
+                    if (isPrev) classes += ' no-left-radius'
+                  } else {
+                    classes += ' confirmedDate'
+                  }
+                }
+                if (inSelectedRange) {
+                  if (isPrevIn && isNextIn) {
+                    classes += ' continuousDate'
+                  } else {
+                    classes += ' selectedByLeader'
+                    if (isPrevIn) classes += ' no-left-radius'
+                    if (isNextIn) classes += ' no-right-radius'
+                  }
+                }
+
+                return classes.trim()
               }
               return null
             }}
@@ -271,7 +328,7 @@ const TripCalendar = ({ tripInfo }) => {
             일정{isRegistred ? ' 수정하기' : ' 등록하기'}
           </button>
 
-          {/**선택한 날짜가 있으면 확정 버튼 보여주기*/}
+          {/** 선택한 날짜가 있으면 확정 버튼 보여주기 */}
           {selectedDates.length > 0 &&
             (() => {
               const sorted = [...selectedDates].sort()

--- a/src/components/trip/TripCalendar.jsx
+++ b/src/components/trip/TripCalendar.jsx
@@ -98,7 +98,7 @@ const TripCalendar = ({ tripInfo }) => {
     }
   }
 
-  /**W2M 캘린더 수정 및 확정 API 호출 */
+  /**W2M 캘린더 수정 API 호출 */
   const updateCalendar = async () => {
     const body = { availableDates: availableDates }
     if (window.confirm('날짜를 확정하시겠습니까?')) {
@@ -127,6 +127,7 @@ const TripCalendar = ({ tripInfo }) => {
   /** 확정 버튼 클릭 시 동작 */
   const handleConfirmDates = () => {
     if (window.confirm('이 날짜들을 확정하시겠습니까?')) {
+      /**여행 일정 확정 API 호출*/
       const updateTripCalendar = async () => {
         const sorted = [...selectedDates].sort()
         const newStartTime = sorted[0] + 'T00:00:00'

--- a/src/config/Env.jsx
+++ b/src/config/Env.jsx
@@ -3,3 +3,4 @@ export const kakaoClientId = import.meta.env.VITE_KAKAO_REST_API_KEY
 export const kakaoRedirectUri = import.meta.env.VITE_KAKAO_REDIRECT_URI
 export const naverClientId = import.meta.env.VITE_NAVER_REST_API_KEY
 export const naverRedirectUri = import.meta.env.VITE_NAVER_REDIRECT_URI
+export const prodBaseUrl = import.meta.env.VITE_PROD_SERVER_BASE_URL


### PR DESCRIPTION
## 구현 배경

- [IL-194](https://ilmansa.atlassian.net/browse/IL-194) 참고
- 방장이 여행 일정을 확정하고자 함

## 작업 사항

- MongoDB 연결 이슈로 환경변수 업데이트(92372e0e75e9febe185160d77979da21d6595ca4)
- 여행 일정 확정을 위한 UI 구현(aa16d97a57311eb83446af1e9ddcc1745cf1c557)
  <details><summary>방장이 일정 선택 시 확정할 수 있는 버튼</summary> <img width="593" height="353" alt="스크린샷 2025-07-13 오후 10 38 08" src="https://github.com/user-attachments/assets/6c0f7252-5e5b-44b1-8252-4ad26f11c307" /></details>
  <details><summary>확정 후 화면에 확정된 날짜 표시</summary> <img width="574" height="299" alt="스크린샷 2025-07-13 오후 10 38 26" src="https://github.com/user-attachments/assets/db599954-e5ca-4d6a-be80-980298784a9a" /></details>

- 새로고침 시 확정된 날짜가 사라지는 현상을 방지하기 위해 `useEffect` 사용하여 해결
- 여행 일정 확정 API 연결
  - 기존 **여행 시간 수정 API** 활용 

 
## 추가 논의

- `react-calendar` 라이브러리 사용에 제한 많음(CSS 등) 이슈로 추후 달력 UI 직접 제작 검토 필요 ‼️💦
- 토요일 날짜가 CSS 적용이 안되는 오류 => 추후 수정 필요


[IL-194]: https://ilmansa.atlassian.net/browse/IL-194?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ