### PR TITLE
Feature(IL-206): 일정 대시보드 UI 및 구조 개선, 탭 기능 통합

### DIFF
--- a/src/components/dashboard/SlideTabs.jsx
+++ b/src/components/dashboard/SlideTabs.jsx
@@ -11,8 +11,8 @@ const SlideTabs = () => {
 
   const tabList = [
     { label: '일정 대시보드' },
-    { label: '갤러리', content: '갤러리 내용' },
-    { label: '즐겨찾는 사진', content: '즐겨찾는 사진 내용' },
+    { label: '갤러리' },
+    { label: '즐겨찾는 사진' },
   ]
 
   const handleTabClick = (index) => {
@@ -23,7 +23,7 @@ const SlideTabs = () => {
   }
 
   return (
-    <div className='w-full'>
+    <div className='w-full overflow-hidden'>
       {/* 탭 바 */}
       <div className='flex'>
         {tabList.map((tab, index) => {
@@ -47,9 +47,7 @@ const SlideTabs = () => {
                 >
                   {tab.label}
                 </div>
-
                 <div className='absolute bottom-0 left-0 z-0 h-[4px] w-full bg-gray-100 shadow-none' />
-
                 {isActive && (
                   <div
                     className='absolute bottom-0 left-0 z-10 h-[4px] w-full'
@@ -61,22 +59,26 @@ const SlideTabs = () => {
           )
         })}
       </div>
-
       <Swiper
         onSwiper={(swiper) => (contentSwiperRef.current = swiper)}
         onSlideChange={(swiper) => setActiveTab(swiper.activeIndex)}
         slidesPerView={1}
         spaceBetween={0}
+        className='w-full overflow-hidden'
       >
-        {tabList.map((tab, index) => (
-          <SwiperSlide key={tab.label}>
-            <div className='mt-5'>
-              {index === 0 && <ScheduleDashBoard />}
-              {index === 1 && <>🖼 갤러리 내용</>}
-              {index === 2 && <>⭐ 즐겨찾는 사진 내용</>}
-            </div>
-          </SwiperSlide>
-        ))}
+        <SwiperSlide className='!w-full'>
+          <div className='mt-5 w-full'>
+            <ScheduleDashBoard />
+          </div>
+        </SwiperSlide>
+
+        <SwiperSlide className='!w-full'>
+          <div className='w-full'>🖼 갤러리 내용</div>
+        </SwiperSlide>
+
+        <SwiperSlide className='!w-full'>
+          <div className='w-full'>⭐ 즐겨찾는 사진 내용</div>
+        </SwiperSlide>
       </Swiper>
     </div>
   )

--- a/src/components/dashboard/TripTitle.jsx
+++ b/src/components/dashboard/TripTitle.jsx
@@ -1,103 +1,84 @@
-import readTripInfoApi from '@/apis/trip/readTripInfo'
-import React, { useEffect, useState } from 'react'
+import { useEffect, useState, useMemo } from 'react'
 import { useParams } from 'react-router-dom'
+import readTripInfoApi from '@/apis/trip/readTripInfo'
 import PinIcon from '@/assets/dashboard/PinIcon'
 import CalendarIcon from '@/assets/dashboard/CalendarIcon'
 import UserIcon from '@/assets/dashboard/UserIcon'
 
 const TripTitle = () => {
   const { tripId } = useParams()
-  const [tripInfo, setTripInfo] = useState()
-  const statusTextMap = {
-    SETTING: '준비중인 여행',
-    PLANNED: '계획중인 여행',
-    PROGRESSED: '진행중인 여행',
-    COMPLETE: '종료된 여행',
-  }
+  const [tripInfo, setTripInfo] = useState(null)
 
   useEffect(() => {
-    const fetchTripInfo = async () => {
+    const fetchTrip = async () => {
       try {
         const result = await readTripInfoApi(tripId)
         setTripInfo(result.data)
       } catch (err) {
-        alert(err.message)
+        alert('여행 정보를 불러오지 못했습니다.')
       }
     }
 
-    if (tripId) fetchTripInfo()
-  }, [])
+    fetchTrip()
+  }, [tripId])
+
+  const statusTextMap = useMemo(
+    () => ({
+      SETTING: '준비중인 여행',
+      PLANNED: '계획중인 여행',
+      PROGRESSED: '진행중인 여행',
+      COMPLETE: '종료된 여행',
+    }),
+    [],
+  )
+
+  const formatDate = (date) =>
+    new Date(date).toLocaleDateString('ko-KR').replace(/. /g, '. ').slice(0, -1)
+
+  if (!tripInfo) return <p>여행 정보를 불러오는 중...</p>
 
   return (
     <div>
-      {tripInfo ? (
-        <div>
-          {/* 상태 + 타이틀 */}
-          <div>
-            <div
-              style={{ color: 'var(--Blue-Scale-blue-500)', fontSize: '14pt' }}
-            >
-              {statusTextMap[tripInfo.status]}
-            </div>
-            <div className='font-bold' style={{ fontSize: '28pt' }}>
-              {tripInfo.title}
-            </div>
-          </div>
-
-          <div
-            className='mt-4 flex flex-col gap-y-1 text-sm text-gray-700'
-            style={{ fontSize: '14pt' }}
-          >
-            {/* 위치 */}
-            <div className='flex items-center gap-2'>
-              <PinIcon className='h-5 w-5' />
-              <div>{tripInfo.city || '???'}</div>
-            </div>
-
-            <div className='flex items-center gap-2'>
-              <CalendarIcon className='h-5 w-5' />
-              <span>
-                {new Date(tripInfo.startedAt)
-                  .toLocaleDateString('ko-KR', {
-                    year: 'numeric',
-                    month: '2-digit',
-                    day: '2-digit',
-                  })
-                  .slice(0, -1)}{' '}
-                -{' '}
-                {new Date(tripInfo.endedAt)
-                  .toLocaleDateString('ko-KR', {
-                    year: 'numeric',
-                    month: '2-digit',
-                    day: '2-digit',
-                  })
-                  .slice(0, -1)}
-              </span>
-            </div>
-
-            <div className='flex items-center gap-2'>
-              <UserIcon className='h-5 w-5' />
-              <ul className='flex gap-1'>
-                {tripInfo.members.map((member) => (
-                  <li key={member.userId}>
-                    {member.imageUrl ? (
-                      <img
-                        src={member.imageUrl}
-                        alt={member.nickname}
-                        className='h-[20px] w-[20px] rounded-full object-cover'
-                      />
-                    ) : (
-                      <div className='h-[20px] w-[20px] rounded-full bg-gray-300' />
-                    )}
-                  </li>
-                ))}
-              </ul>
-            </div>
-          </div>
+      <div>
+        <div
+          className='text-[14pt]'
+          style={{ color: 'var(--Blue-Scale-blue-500)' }}
+        >
+          {statusTextMap[tripInfo.status]}
         </div>
-      ) : (
-        <p>여행 정보를 불러오는 중...</p>
-      )}
+        <div className='text-[28pt] font-bold'>{tripInfo.title}</div>
+      </div>
+
+      <div className='mt-4 flex flex-col gap-y-1 text-[14pt] text-gray-700'>
+        <div className='flex items-center gap-2'>
+          <PinIcon className='h-5 w-5' />
+          <div>{tripInfo.city || '???'}</div>
+        </div>
+        <div className='flex items-center gap-2'>
+          <CalendarIcon className='h-5 w-5' />
+          <span>
+            {formatDate(tripInfo.startedAt)} - {formatDate(tripInfo.endedAt)}
+          </span>
+        </div>
+        <div className='flex items-center gap-2'>
+          <UserIcon className='h-5 w-5' />
+          <ul className='flex gap-1'>
+            {tripInfo.members.map((member) => (
+              <li key={member.userId}>
+                {member.imageUrl ? (
+                  <img
+                    src={member.imageUrl}
+                    alt={member.nickname}
+                    className='h-[20px] w-[20px] rounded-full object-cover'
+                  />
+                ) : (
+                  <div className='h-[20px] w-[20px] rounded-full bg-gray-300' />
+                )}
+              </li>
+            ))}
+          </ul>
+        </div>
+      </div>
     </div>
   )
 }

--- a/src/components/dashboard/schedule/DateBox.jsx
+++ b/src/components/dashboard/schedule/DateBox.jsx
@@ -2,7 +2,7 @@ import ArrowUp from '@/assets/dashboard/ArrowUp'
 import ArrowDown from '@/assets/dashboard/ArrowDown'
 import { useState } from 'react'
 
-const DateBox = () => {
+const DateBox = ({ date }) => {
   const [isOpen, setIsOpen] = useState(false)
 
   const toggleOpen = () => setIsOpen((prev) => !prev)
@@ -13,7 +13,7 @@ const DateBox = () => {
         className='flex cursor-pointer items-center justify-between'
         onClick={toggleOpen}
       >
-        <div className='text-[16px] text-gray-500'>Date</div>
+        <div className='text-base text-gray-400'>{date || '여행 전체'}</div>
         {isOpen ? (
           <ArrowUp
             className='text-gray-400 transition-transform duration-300'
@@ -30,7 +30,7 @@ const DateBox = () => {
       {isOpen && (
         <div className='mt-[5px] py-10 text-center text-base text-gray-400'>
           아직 예정된 일정이 없어요
-          <div className='mt-2 text-base text-[var(--Blue-Scale-blue-500)]'>
+          <div className='mt-2 cursor-pointer text-base text-[var(--Blue-Scale-blue-500)]'>
             + 일정 담으러 가기
           </div>
         </div>

--- a/src/components/dashboard/schedule/DayTabs.jsx
+++ b/src/components/dashboard/schedule/DayTabs.jsx
@@ -1,47 +1,74 @@
-import { useRef, useState } from 'react'
-import { Swiper, SwiperSlide } from 'swiper/react'
-import 'swiper/css'
+import { useEffect, useState } from 'react'
 import DateBox from './DateBox'
 
-const DayTabs = () => {
+const DayTabs = ({ startedAt, endedAt }) => {
   const [activeTab, setActiveTab] = useState(0)
-  const contentSwiperRef = useRef(null)
+  const [dates, setDates] = useState([])
 
-  /** 추후 일정 개수에 따라 확장 가능 */
-  const tabList = [{ label: '여행 전체' }]
+  const formatDateToDot = (dateObj) => {
+    const year = dateObj.getFullYear()
+    const month = String(dateObj.getMonth() + 1).padStart(2, '0')
+    const day = String(dateObj.getDate()).padStart(2, '0')
+    return `${year}. ${month}. ${day}`
+  }
+
+  useEffect(() => {
+    if (!startedAt || !endedAt) return
+
+    const start = new Date(startedAt)
+    const end = new Date(endedAt)
+
+    const tempDates = []
+    const cur = new Date(start.getFullYear(), start.getMonth(), start.getDate())
+
+    while (cur <= end) {
+      tempDates.push(new Date(cur))
+      cur.setDate(cur.getDate() + 1)
+    }
+
+    setDates(tempDates)
+  }, [startedAt, endedAt])
 
   const handleTabClick = (index) => {
     setActiveTab(index)
-    contentSwiperRef.current?.slideTo(index)
   }
 
   return (
     <div className='w-full'>
       {/* 탭 바 */}
       <div className='flex flex-wrap gap-[6px]'>
-        {tabList.map((tab, index) => {
-          const isActive = index === activeTab
-          return (
-            <div
-              key={tab.label}
-              onClick={() => handleTabClick(index)}
-              className={`cursor-pointer rounded-full px-4 py-1 text-base ${
-                isActive
-                  ? 'bg-[var(--Blue-Scale-blue-500)] text-white'
-                  : 'border border-gray-300 bg-white text-gray-500'
-              }`}
-            >
-              {tab.label}
-            </div>
-          )
-        })}
+        <div
+          className={`cursor-pointer rounded-full px-4 py-1 text-base ${
+            activeTab === 0
+              ? 'bg-[var(--Blue-Scale-blue-500)] text-white'
+              : 'border border-gray-300 bg-white text-gray-500'
+          }`}
+          onClick={() => handleTabClick(0)}
+        >
+          여행 전체
+        </div>
+
+        {dates.map((_, index) => (
+          <div
+            key={index}
+            onClick={() => handleTabClick(index + 1)}
+            className={`cursor-pointer rounded-full px-4 py-1 text-base ${
+              activeTab === index + 1
+                ? 'bg-[var(--Blue-Scale-blue-500)] text-white'
+                : 'border border-gray-300 bg-white text-gray-500'
+            }`}
+          >
+            DAY {index + 1}
+          </div>
+        ))}
       </div>
 
-      {/* 콘텐츠 영역 */}
-      <div className='mt-4'>
-        <div className='flex flex-col gap-3'>
-          <DateBox />
-        </div>
+      <div className='mt-4 flex flex-col gap-3'>
+        {activeTab === 0
+          ? dates.map((d, i) => <DateBox key={i} date={formatDateToDot(d)} />)
+          : dates[activeTab - 1] && (
+              <DateBox date={formatDateToDot(dates[activeTab - 1])} />
+            )}
       </div>
     </div>
   )

--- a/src/components/dashboard/schedule/ScheduleDashBoard.jsx
+++ b/src/components/dashboard/schedule/ScheduleDashBoard.jsx
@@ -1,12 +1,28 @@
-import React from 'react'
+import { useEffect, useState } from 'react'
+import { useParams } from 'react-router-dom'
+import readTripInfoApi from '@/apis/trip/readTripInfo'
 import DayTabs from './DayTabs'
 
 const ScheduleDashBoard = () => {
-  return (
-    <>
-      <DayTabs />
-    </>
-  )
+  const { tripId } = useParams()
+  const [tripInfo, setTripInfo] = useState(null)
+
+  useEffect(() => {
+    const fetchTrip = async () => {
+      try {
+        const result = await readTripInfoApi(tripId)
+        setTripInfo(result.data)
+      } catch (err) {
+        alert('여행 정보를 불러오지 못했습니다.')
+      }
+    }
+
+    fetchTrip()
+  }, [tripId])
+
+  if (!tripInfo) return null
+
+  return <DayTabs startedAt={tripInfo.startedAt} endedAt={tripInfo.endedAt} />
 }
 
 export default ScheduleDashBoard

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -7,14 +7,12 @@ const Dashboard = () => {
   const navigate = useNavigate()
   const { tripId } = useParams()
 
-  /**뒤로 가기 버튼 */
   const handleBack = () => {
     navigate(`/trip/${tripId}`)
   }
 
   return (
     <div className='flex w-full flex-col pt-5'>
-      {/* 뒤로 가기 버튼 */}
       <div>
         <button
           className='text-bold my-2 border-none px-4'
@@ -24,10 +22,8 @@ const Dashboard = () => {
         </button>
       </div>
 
-      {/* 여행 타이틀 */}
       <div className='flex w-full flex-col gap-15 px-10 pt-10 pb-10'>
         <TripTitle />
-        {/* 탭 창 구현 */}
         <SlideTabs />
       </div>
     </div>


### PR DESCRIPTION
## 구현 배경

- [IL-206](https://ilmansa.atlassian.net/browse/IL-206) 참고
- 사용자의 여행 일정에 따라 대시보드를 활용하고자 함

## 작업 사항

- 여행 일정 대시보드 기능을 SlideTabs 구조 내에 통합하고, 일정 탭별 UI를 개선
- TripTitle, DayTabs, DateBox 구성 분리 및 재사용성을 고려한 컴포넌트 구조화
  - props 전달 구조 개선
  - ScheduleDashBoard 컴포넌트를 SlideTabs 내부로 이동
 - DayTabs 컴포넌트에서 시작일~종료일 기반 날짜 목록 생성 및 DAY 탭 렌더링
 
## 추가 논의

- ~`/trip/:tripId/dashboard`접속하여 확인해주시고, amplify 작동 안되면 말씀해주세요!~
  - 현재 amplify에서 카카오 로그인이 안되고 있는 것 같아서 UI 일부 이미지 첨부합니다 🤳

[IL-206]: https://ilmansa.atlassian.net/browse/IL-206?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ