### PR TITLE
Feature(IL-234): 여행 참가 페이지 UI 리디자인

### DIFF
--- a/src/assets/dashboard/modal/LocationIcon.jsx
+++ b/src/assets/dashboard/modal/LocationIcon.jsx
@@ -1,0 +1,29 @@
+import React from 'react'
+
+const LocationIcon = ({ className }) => {
+  return (
+    <svg
+      className={className}
+      viewBox='0 0 18 18'
+      fill='none'
+      xmlns='http://www.w3.org/2000/svg'
+      stroke='currentColor'
+      style={{ transform: 'translateX(2px)' }}
+    >
+      <path
+        d='M7 9.75C8.24264 9.75 9.25 8.74264 9.25 7.5C9.25 6.25736 8.24264 5.25 7 5.25C5.75736 5.25 4.75 6.25736 4.75 7.5C4.75 8.74264 5.75736 9.75 7 9.75Z'
+        strokeWidth='1.5'
+        strokeLinecap='round'
+        strokeLinejoin='round'
+      />
+      <path
+        d='M7 16.5C10 13.5 13 10.8137 13 7.5C13 4.18629 10.3137 1.5 7 1.5C3.68629 1.5 1 4.18629 1 7.5C1 10.8137 4 13.5 7 16.5Z'
+        strokeWidth='1.5'
+        strokeLinecap='round'
+        strokeLinejoin='round'
+      />
+    </svg>
+  )
+}
+
+export default LocationIcon

--- a/src/pages/Participation.jsx
+++ b/src/pages/Participation.jsx
@@ -1,5 +1,7 @@
 import createMemberApi from '@/apis/member/createMemberApi'
 import readTripInfoApi from '@/apis/trip/readTripInfo'
+import LocationIcon from '@/assets/dashboard/modal/LocationIcon'
+import { CalendarIcon, PinIcon, UserIcon } from 'lucide-react'
 import { useEffect, useState } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
 
@@ -8,6 +10,7 @@ const Participation = () => {
   const { tripId } = useParams()
   const navigate = useNavigate()
   const [tripInfo, setTripInfo] = useState()
+  const [isScheduleConfirmed, setIsScheduleConfirmed] = useState(false)
 
   useEffect(() => {
     /**여행 정보 조회 API 호출 */
@@ -34,56 +37,101 @@ const Participation = () => {
     }
   }
 
+  /** 리더 닉네임 */
+  const leaderNickname =
+    tripInfo?.members.find((member) => member.userId === tripInfo.leaderId)
+      ?.nickname ?? tripInfo?.leaderId
+
+  /** 디데이 함수 */
+  const calculateDday = (startDateString) => {
+    if (!startDateString) return 'D-??'
+    const today = new Date()
+    const startDate = new Date(startDateString)
+
+    today.setHours(0, 0, 0, 0)
+    startDate.setHours(0, 0, 0, 0)
+
+    const diffTime = startDate.getTime() - today.getTime()
+    const diffDays = Math.ceil(diffTime / (1000 * 60 * 60 * 24))
+
+    if (diffDays > 0) return `D-${diffDays}`
+    if (diffDays === 0) return 'D-Day'
+    return `D+${Math.abs(diffDays)}`
+  }
+
   return (
     <div className='flex h-screen w-full flex-col items-center justify-center rounded-2xl px-6 py-5'>
       {tripInfo ? (
         <div>
-          <div className='flex flex-col gap-5 rounded-2xl border border-gray-100 bg-white p-4 shadow-md'>
+          <div className='flex w-[380px] flex-col gap-5 rounded-2xl border border-gray-100 bg-white p-4 shadow-md'>
             <div className='flex justify-between'>
-              <h2 className='mt-auto text-base font-semibold text-gray-900'>
-                <span style={{ color: 'var(--Blue-Scale-blue-500)' }}>
-                  {tripInfo.title}
-                </span>
-                에 참가하시겠습니까?
+              <h2 className='mt-3 text-xl font-semibold text-gray-900'>
+                {leaderNickname}님이 보낸 여행요청을
+                <br />
+                수락하시겠어요?
+                <p className='mt-1 text-sm font-medium text-gray-500'>
+                  요청을 수락하면 바로 합류할 수 있어요
+                </p>
               </h2>
             </div>
+            <div className='flex w-full flex-col gap-2 rounded-[20px] bg-[var(--Blue-Scale-blue-100)] p-4'>
+              <div className='flex items-center gap-2'>
+                <div className='rounded-full bg-white px-2 py-1 text-xs font-medium text-[var(--Blue-Scale-blue-500)] shadow-sm'>
+                  {calculateDday(tripInfo.startedAt)}
+                </div>
+                <h3 className='text-lg font-bold text-gray-900'>
+                  {tripInfo.title}
+                </h3>
+              </div>
 
-            <ul className='flex gap-4'>
-              {tripInfo.members.map((member) => (
-                <li
-                  key={member.userId}
-                  className='flex w-10 flex-col items-center gap-1'
-                >
-                  <span className='h-4 text-sm leading-none'>
-                    {member.userId === tripInfo.leaderId ? '👑' : '\u00A0'}
+              {/** 위치, 일정, 참가중인 멤버 */}
+              <div className='flex flex-col gap-y-1 text-[14px] font-medium text-gray-500'>
+                <div className='flex items-center gap-2'>
+                  <LocationIcon className='h-5 w-5 text-gray-500' />
+                  <span>{tripInfo.city || '아직 정해지지 않았어요'}</span>
+                </div>
+
+                <div className='flex items-center gap-2'>
+                  <CalendarIcon className='h-5 w-5' />
+                  <span>
+                    {isScheduleConfirmed
+                      ? `${formatDate(tripInfo.startedAt)} - ${formatDate(tripInfo.endedAt)}`
+                      : '아직 정해지지 않았어요'}
                   </span>
-                  {member.imageUrl ? (
-                    <img
-                      src={member.imageUrl}
-                      alt='프로필 이미지'
-                      className='h-8 w-8 cursor-pointer rounded-full object-cover'
-                    />
-                  ) : (
-                    <div className='flex h-8 w-8 items-center justify-center rounded-full bg-gray-200 text-xs text-gray-500'>
-                      없음
-                    </div>
-                  )}
-                </li>
-              ))}
-            </ul>
+                </div>
+                <div className='flex items-center gap-2'>
+                  <UserIcon className='h-5 w-5' />
+                  <ul className='flex gap-1'>
+                    {tripInfo.members.map((member) => (
+                      <li key={member.userId}>
+                        {member.imageUrl ? (
+                          <img
+                            src={member.imageUrl}
+                            alt={member.nickname}
+                            className='h-[20px] w-[20px] rounded-full object-cover'
+                          />
+                        ) : (
+                          <div className='h-[20px] w-[20px] rounded-full bg-gray-300' />
+                        )}
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              </div>
+            </div>
 
             <div className='flex w-full gap-3'>
               <button
                 className='font-large text-m text-grey-400 w-1/2 rounded-xl border-none bg-gray-100 px-4 py-3 font-semibold outline-none'
                 onClick={() => navigate('/')}
               >
-                취소하기
+                취소
               </button>
               <button
                 className='font-large text-m w-1/2 rounded-xl border-none bg-[var(--Blue-Scale-blue-500)] px-4 py-3 font-semibold text-white outline-none'
                 onClick={createMember}
               >
-                참가하기
+                수락하기
               </button>
             </div>
           </div>

--- a/src/pages/Participation.jsx
+++ b/src/pages/Participation.jsx
@@ -66,9 +66,7 @@ const Participation = () => {
           <div className='flex w-[380px] flex-col gap-5 rounded-2xl border border-gray-100 bg-white p-4 shadow-md'>
             <div className='flex justify-between'>
               <h2 className='mt-3 text-xl font-semibold text-gray-900'>
-                {leaderNickname}님이 보낸 여행요청을
-                <br />
-                수락하시겠어요?
+                여행 초대 요청을 수락하시겠어요?
                 <p className='mt-1 text-sm font-medium text-gray-500'>
                   요청을 수락하면 바로 합류할 수 있어요
                 </p>


### PR DESCRIPTION
## 구현 배경

- [지난 여행참가 페이지 UI PR](https://github.com/Team-Ilmansa/yeogiga-web/pull/88#issue-3276063623) 참고
- UI 디자인 변동에 따라 스타일링 변경

## 작업 사항

- 페이지 UI redesign
- 대시보드 페이지의 타이틀 부분 코드 참고

## 추가 논의

- 현재는 '(방장 닉네임)의 여행에 참가~' 인데 초대 링크는 여행 참여 멤버 모두가 보낼 수 있는 부분이라 생각을 해서 방장 닉네임 대신 차라리 **여행 이름**으로 수정하는 것이 어떨까요? 코멘트 부탁드립니다~!
