### PR TITLE
Feature(IL-237): 전체 공지사항 조회 API 및 공지사항 UI 구현

### DIFF
--- a/src/apis/notice/readNoticeApi.jsx
+++ b/src/apis/notice/readNoticeApi.jsx
@@ -1,0 +1,21 @@
+import api from '@/apis/api'
+
+/**전체 공지사항 조회 API */
+const readNoticeApi = async (tripId) => {
+  try {
+    const response = await api.get(`trip/${tripId}/notices`)
+    return response.data
+  } catch (err) {
+    if (err.response?.data?.message) {
+      throw new Error(err.response.data.message)
+    } else if (err.response) {
+      throw new Error(`오류 발생 (status: ${err.response.status})`)
+    } else if (err.request) {
+      throw new Error('서버로부터 응답이 없습니다.')
+    } else {
+      throw new Error('요청 중 알 수 없는 오류가 발생했습니다.')
+    }
+  }
+}
+
+export default readNoticeApi

--- a/src/assets/dashboard/PinIcon.jsx
+++ b/src/assets/dashboard/PinIcon.jsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-const UserIcon = ({ className }) => {
+const PinIcon = ({ className }) => {
   return (
     <div className='flex flex-col items-center'>
       <svg
@@ -28,4 +28,4 @@ const UserIcon = ({ className }) => {
   )
 }
 
-export default UserIcon
+export default PinIcon

--- a/src/assets/dashboard/PlaceIcon.jsx
+++ b/src/assets/dashboard/PlaceIcon.jsx
@@ -1,0 +1,25 @@
+import React from 'react'
+
+const PlaceIcon = ({ className }) => {
+  return (
+    <div>
+      <svg
+        width='22'
+        height='21'
+        viewBox='0 0 22 21'
+        fill='none'
+        xmlns='http://www.w3.org/2000/svg'
+      >
+        <path
+          d='M15 11.3744C18.5318 12.0688 21 13.6547 21 15.5C21 17.9853 16.5228 20 11 20C5.47715 20 1 17.9853 1 15.5C1 13.6547 3.46819 12.0688 7 11.3744M11 15V7M11 7C12.6569 7 14 5.65685 14 4C14 2.34315 12.6569 1 11 1C9.34315 1 8 2.34315 8 4C8 5.65685 9.34315 7 11 7Z'
+          stroke='#8287FF'
+          stroke-width='2'
+          stroke-linecap='round'
+          stroke-linejoin='round'
+        />
+      </svg>
+    </div>
+  )
+}
+
+export default PlaceIcon

--- a/src/components/notice/Notices.jsx
+++ b/src/components/notice/Notices.jsx
@@ -25,15 +25,18 @@ const Notices = () => {
     }
   }, [user, tripId])
 
+  /**보라색 박스 공통 스타일링 지정 */
   const containerStyle =
-    'flex items-center gap-3 rounded-2xl bg-indigo-50  px-4 py-5'
+    'flex items-center gap-3 rounded-2xl bg-[var(--Blue-Scale-blue-100)]  px-4 py-5'
+  /**폰트 스타일링 지정 */
   const fontStyle = 'text-base font-medium text-gray-700'
 
   return (
     <div className='space-y-2'>
-      {/* 헤더 영역 */}
+      {/**헤더 영역 */}
       <div className='flex items-center justify-between'>
         <h1 className='text-3xl leading-normal font-bold'>현재 공지</h1>
+        {/* TODO: 지난 공지 전체보기 버튼 연결 */}
         <button className='mt-2 flex items-center border-none text-base text-gray-400 hover:text-gray-500'>
           지난 공지 전체보기
         </button>

--- a/src/components/notice/Notices.jsx
+++ b/src/components/notice/Notices.jsx
@@ -44,7 +44,7 @@ const Notices = () => {
 
       {/**현재 공지 리스트 */}
       <div className='space-y-3'>
-        {/**집결지 */}
+        {/* TODO: 집결지 API 연동 */}
         <div className={containerStyle}>
           <PlaceIcon className='h-6 w-6' />
           <div className='flex items-baseline gap-2'>

--- a/src/components/notice/Notices.jsx
+++ b/src/components/notice/Notices.jsx
@@ -1,0 +1,72 @@
+import PlaceIcon from '@/assets/dashboard/PlaceIcon'
+import { Archive } from 'lucide-react'
+import { useEffect, useState } from 'react'
+import useAuth from '@/hooks/useAuth'
+import readNoticeApi from '@/apis/notice/readNoticeApi'
+import { useParams } from 'react-router-dom'
+
+const Notices = () => {
+  const { user } = useAuth()
+  const { tripId } = useParams()
+  const [notices, setNotices] = useState([])
+
+  /**전체 공지사항 조회 API 호출 */
+  useEffect(() => {
+    if (user && tripId) {
+      const fetchNotice = async () => {
+        try {
+          const result = await readNoticeApi(tripId)
+          setNotices(result.data.content)
+        } catch (err) {
+          console.error(err)
+        }
+      }
+      fetchNotice()
+    }
+  }, [user, tripId])
+
+  const containerStyle =
+    'flex items-center gap-3 rounded-2xl bg-indigo-50  px-4 py-5'
+  const fontStyle = 'text-base font-medium text-gray-700'
+
+  return (
+    <div className='space-y-2'>
+      {/* 헤더 영역 */}
+      <div className='flex items-center justify-between'>
+        <h1 className='text-3xl leading-normal font-bold'>현재 공지</h1>
+        <button className='mt-2 flex items-center border-none text-base text-gray-400 hover:text-gray-500'>
+          지난 공지 전체보기
+        </button>
+      </div>
+
+      {/**현재 공지 리스트 */}
+      <div className='space-y-3'>
+        {/**집결지 */}
+        <div className={containerStyle}>
+          <PlaceIcon className='h-6 w-6' />
+          <div className='flex items-baseline gap-2'>
+            <span className={fontStyle}>Text</span>
+            <span className='text-sm text-indigo-300'>Time</span>
+          </div>
+        </div>
+
+        {/** 공지사항 */}
+        {notices.length === 0 ? (
+          <div className={containerStyle}>
+            <Archive className='h-6 w-6 text-[var(--Blue-Scale-blue-500)]' />
+            <div className={fontStyle}>현재 공지사항 없음</div>
+          </div>
+        ) : (
+          notices.map((notice, index) => (
+            <div key={index} className={containerStyle}>
+              <Archive className='h-6 w-6 text-indigo-400' />
+              <div className={fontStyle}>{notice.title || '제목 없음'}</div>
+            </div>
+          ))
+        )}
+      </div>
+    </div>
+  )
+}
+
+export default Notices

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -7,6 +7,7 @@ import KebabIcon from '@/assets/dashboard/KebabIcon'
 import readMyCalendarApi from '@/apis/calendar/readMyCalendarApi'
 import KebabModal from '@/components/dashboard/modal/KebabModal'
 import UpdateTitleModal from '@/components/dashboard/modal/UpdateTitleModal'
+import Notices from '@/components/notice/Notices'
 
 /**여행 정보 대시보드 페이지 */
 const Dashboard = () => {
@@ -76,6 +77,7 @@ const Dashboard = () => {
             isScheduleConfirmed={isScheduleConfirmed}
             setIsScheduleConfirmed={setIsScheduleConfirmed}
           />
+          <Notices />
           <SlideTabs isScheduleConfirmed={isScheduleConfirmed} />
         </div>
         {/* 여행 날짜 확정 버튼 */}


### PR DESCRIPTION
## 구현 배경

- [IL-237](https://ilmansa.atlassian.net/browse/IL-237) 참고
- 사용자가 공지사항을 조회하고자 함

## 작업 사항

- 전체 공지사항 조회 API 로직 구현
- 집결지핀 아이콘 컴포넌트 구현
- `Notices` 컴포넌트 구현 

## 추가 논의

- 현재 구현되어 있는 PinIcon과 이 코드에서 쓰인 PlaceIcon의 쓰임이 헷갈려서 추후 컴포넌트명 변경이 필요할 것 같아요~ @gugitgugit 
- 추후 페이지 or API 연동이 필요한 부분은 TODO로 주석처리
- 현재 공지의 집결지 아래에 있는 `Archive` 컴포넌트에 우선 공지사항 렌더링되도록 구현


[IL-237]: https://ilmansa.atlassian.net/browse/IL-237?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ