### PR TITLE
Feature(IL-238): 공지사항 생성 API 연동 구현

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -13,6 +13,7 @@ import ConfirmCalendar from './pages/ConfirmCalendar'
 import TripCalendar from './pages/TripCalendar'
 import ProtectedRoute from './components/common/ProtectedRoute'
 import UpdateCalendar from './pages/UpdateCalendar'
+import CreateNotices from './components/notice/CreateNotices'
 
 const App = () => {
   return (
@@ -36,6 +37,8 @@ const App = () => {
                 <Route path='update' element={<UpdateCalendar />} />
                 <Route path='confirmation' element={<ConfirmCalendar />} />
                 <Route path='participation' element={<Participation />} />
+                {/* TODO: 추후 Notice 페이지와 결합 */}
+                <Route path='post/notice' element={<CreateNotices />} />
               </Route>
             </Route>
           </Routes>

--- a/src/apis/notice/createNoticeApi.jsx
+++ b/src/apis/notice/createNoticeApi.jsx
@@ -1,0 +1,21 @@
+import api from '@/apis/api'
+
+/**공지사항 생성 API */
+const createNoticeApi = async (tripId, body) => {
+  try {
+    const response = await api.post(`trip/${tripId}/notices`, body)
+    return response.data
+  } catch (err) {
+    if (err.response?.data?.message) {
+      throw new Error(err.response.data.message)
+    } else if (err.response) {
+      throw new Error(`오류 발생 (status: ${err.response.status})`)
+    } else if (err.request) {
+      throw new Error('서버로부터 응답이 없습니다.')
+    } else {
+      throw new Error('요청 중 알 수 없는 오류가 발생했습니다.')
+    }
+  }
+}
+
+export default createNoticeApi

--- a/src/components/notice/CreateNotices.jsx
+++ b/src/components/notice/CreateNotices.jsx
@@ -1,0 +1,69 @@
+import createNoticeApi from '@/apis/notice/createNoticeApi'
+import React, { useState } from 'react'
+import { useNavigate, useParams } from 'react-router-dom'
+
+const CreateNotices = () => {
+  const { tripId } = useParams()
+  const navigate = useNavigate()
+  const [titleNotices, setTitleNotices] = useState('')
+  const [descNotices, setDescTitleNotices] = useState('')
+
+  /**공지사항 생성 API 호출 */
+  const createNotice = async () => {
+    try {
+      const result = await createNoticeApi(tripId, {
+        title: titleNotices,
+        description: descNotices,
+      })
+    } catch (err) {
+      alert(err.message)
+    }
+  }
+  return (
+    <div className='flex h-screen w-full flex-col items-center justify-center rounded-2xl px-6 py-5'>
+      <div>
+        <div className='flex w-[380px] flex-col gap-5 rounded-2xl border border-gray-100 bg-white p-4 shadow-md'>
+          <div className='flex justify-between'>
+            <h2 className='mt-3 text-xl font-semibold text-gray-900'>
+              공지사항을 작성할 수 있어요
+            </h2>
+          </div>
+          {/** 제목 입력란 */}
+          <input
+            type='text'
+            value={titleNotices}
+            onChange={(e) => setTitleNotices(e.target.value)}
+            placeholder='제목을 작성해주세요'
+            className='w-full rounded-[20px] border-none bg-[var(--Grey-Scale-grey-100)] p-4 text-base outline-none'
+          />
+
+          {/** 내용 입력 */}
+          <textarea
+            value={descNotices}
+            onChange={(e) => setDescTitleNotices(e.target.value)}
+            placeholder='공지사항을 작성해주세요'
+            rows={6}
+            className='w-full resize-none rounded-[20px] bg-[var(--Grey-Scale-grey-100)] p-4 text-base outline-none'
+          ></textarea>
+
+          <div className='flex w-full gap-3'>
+            <button
+              className='font-large text-m text-grey-400 w-1/2 rounded-xl border-none bg-gray-100 px-4 py-3 font-semibold outline-none'
+              onClick={() => navigate('/')}
+            >
+              취소
+            </button>
+            <button
+              className='font-large text-m w-1/2 rounded-xl border-none bg-[var(--Blue-Scale-blue-500)] px-4 py-3 font-semibold text-white outline-none'
+              onClick={createNotice}
+            >
+              작성하기
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default CreateNotices

--- a/src/components/notice/Notices.jsx
+++ b/src/components/notice/Notices.jsx
@@ -54,6 +54,7 @@ const Notices = () => {
         </div>
 
         {/** 공지사항 */}
+        {/* TODO: 가장 최신 공지사항 하나만 보이도록 구현(지난 공지  전체보기 구현 후) */}
         {notices.length === 0 ? (
           <div className={containerStyle}>
             <Archive className='h-6 w-6 text-[var(--Blue-Scale-blue-500)]' />


### PR DESCRIPTION
## 구현 배경

- [IL-238](https://ilmansa.atlassian.net/browse/IL-238) 참고
- 사용자가 공지사항을 작성하고자 함

## 작업 사항

- 공지사항 생성 API 연동(d1e15025192b540d47462819f3602005f4c61363)

## 추가 논의

- 공지사항 생성 API 테스트를 위해서 임시로 `/post/notice` 로 경로 설정하여 페이지 구현
  - 추후 디자인에 따라 Notices 컴포넌트와 결합할 예정입니다~
- 지난 공지 전체보기 디자인 반영 시 대시보드에서는 가장 최신 공지사항 하나만 올리도록 구현하겠습니다!(TODO)
- Notice 관련 label 임시 지정해두었는데 괜찮으시면 이대로 지정하겠습니당


[IL-238]: https://ilmansa.atlassian.net/browse/IL-238?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ