### PR TITLE
Feature(IL-239): 공지사항 삭제 API 연동 구현

### DIFF
--- a/src/apis/notice/deleteNoticeApi.jsx
+++ b/src/apis/notice/deleteNoticeApi.jsx
@@ -1,0 +1,21 @@
+import api from '@/apis/api'
+
+/**공지사항 삭제 API */
+const deleteNoticeApi = async (tripId, noticeId) => {
+  try {
+    const response = await api.delete(`trip/${tripId}/notices/${noticeId}`)
+    return response.data
+  } catch (err) {
+    if (err.response?.data?.message) {
+      throw new Error(err.response.data.message)
+    } else if (err.response) {
+      throw new Error(`오류 발생 (status: ${err.response.status})`)
+    } else if (err.request) {
+      throw new Error('서버로부터 응답이 없습니다.')
+    } else {
+      throw new Error('요청 중 알 수 없는 오류가 발생했습니다.')
+    }
+  }
+}
+
+export default deleteNoticeApi

--- a/src/components/notice/Notices.jsx
+++ b/src/components/notice/Notices.jsx
@@ -3,12 +3,16 @@ import { Archive } from 'lucide-react'
 import { useEffect, useState } from 'react'
 import useAuth from '@/hooks/useAuth'
 import readNoticeApi from '@/apis/notice/readNoticeApi'
-import { useParams } from 'react-router-dom'
+import { useNavigate, useParams } from 'react-router-dom'
+import deleteNoticeApi from '@/apis/notice/deleteNoticeApi'
 
 const Notices = () => {
   const { user } = useAuth()
   const { tripId } = useParams()
+  const navigate = useNavigate()
   const [notices, setNotices] = useState([])
+  const [selectedNoticeId, setSelectedNoticeId] = useState(null)
+  const [isModalOpen, setIsModalOpen] = useState(false)
 
   /**전체 공지사항 조회 API 호출 */
   useEffect(() => {
@@ -25,14 +29,70 @@ const Notices = () => {
     }
   }, [user, tripId])
 
+  /**공지사항 삭제 API 호출 */
+  const deleteNotice = async () => {
+    if (!selectedNoticeId) return
+
+    try {
+      await deleteNoticeApi(tripId, selectedNoticeId)
+      alert('정상적으로 삭제되었습니다.')
+      const result = await readNoticeApi(tripId)
+      setNotices(result.data.content)
+      setIsModalOpen(false)
+      setSelectedNoticeId(null)
+    } catch (err) {
+      alert(err.message)
+    }
+  }
+
+  /**공지사항 클릭 시 모달 열기 */
+  const handleNoticeClick = (id) => {
+    setSelectedNoticeId(id)
+    setIsModalOpen(true)
+  }
+
   /**보라색 박스 공통 스타일링 지정 */
   const containerStyle =
     'flex items-center gap-3 rounded-2xl bg-[var(--Blue-Scale-blue-100)]  px-4 py-5'
   /**폰트 스타일링 지정 */
   const fontStyle = 'text-base font-medium text-gray-700'
+  /**모달 버튼 스타일링 지정 */
+  const modalButtonStyle =
+    'rounded-xl bg-gray-100 text-m font-semibold text-gray-600 border-none w-1/2'
 
   return (
     <div className='space-y-2'>
+      {/**삭제 모달 */}
+      {/* TODO: 모달 위치 옮기기 */}
+      {isModalOpen && (
+        <div className='fixed inset-0 z-50 flex items-center justify-center bg-black/50'>
+          <div className='h-[180px] w-[380px] rounded-2xl bg-white p-6 shadow-xl'>
+            <h3 className='mb-2 text-lg font-semibold text-gray-900'>
+              공지를 정말로 삭제하시겠어요?
+            </h3>
+            <p className='mb-4 text-sm'>삭제한 공지는 복구할 수 없어요.</p>
+            <div className='mt-10 flex gap-2'>
+              <button
+                className={modalButtonStyle}
+                onClick={() => {
+                  setIsModalOpen(false)
+                  setSelectedNoticeId(null)
+                }}
+              >
+                취소
+              </button>
+              <button
+                className={modalButtonStyle}
+                onClick={deleteNotice}
+                style={{ color: '#FF0000' }}
+              >
+                삭제하기
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
       {/**헤더 영역 */}
       <div className='flex items-center justify-between'>
         <h1 className='text-3xl leading-normal font-bold'>현재 공지</h1>
@@ -61,8 +121,12 @@ const Notices = () => {
             <div className={fontStyle}>현재 공지사항 없음</div>
           </div>
         ) : (
-          notices.map((notice, index) => (
-            <div key={index} className={containerStyle}>
+          notices.map((notice) => (
+            <div
+              key={notice.id}
+              className={containerStyle}
+              onClick={() => handleNoticeClick(notice.id)} // ✅ 클릭 시 모달 오픈
+            >
               <Archive className='h-6 w-6 text-indigo-400' />
               <div className={fontStyle}>{notice.title || '제목 없음'}</div>
             </div>


### PR DESCRIPTION
## 구현 배경

- [IL-239](https://ilmansa.atlassian.net/browse/IL-239) 참고
- 사용자가 공지사항을 삭제하고자 함

## 작업 사항

- 공지사항 삭제 API 연동
- 공지사항 삭제 연동 모달 구현

## 추가 논의

- 우선은 대시보드 페이지에서 공지사항을 클릭했을 때 `삭제하시겠습니까?` 모달 열리도록 구현해뒀는데 디자인에 따라 추후 위치 변동 예정(TODO)


[IL-239]: https://ilmansa.atlassian.net/browse/IL-239?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ