### PR TITLE
Feature(IL-242): 네이버 지도 API 연결

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -29,6 +29,7 @@ jobs:
           VITE_NAVER_REDIRECT_URI: ${{ secrets.VITE_NAVER_REDIRECT_URI }}
           VITE_SERVER_BASE_URL: ${{ secrets.VITE_SERVER_BASE_URL }}
           VITE_PROD_SERVER_BASE_URL: ${{ secrets.VITE_PROD_SERVER_BASE_URL }}
+          VITE_NAVER_MAP_KEY: ${{ secrets.VITE_NAVER_MAP_KEY}}
 
         run: |
           npm install

--- a/index.html
+++ b/index.html
@@ -22,6 +22,12 @@
     <meta property="og:url" content="https://yeogiga.com" />
     <meta property="og:type" content="website" />
 
+    <!-- Naver 지도 불러오기 -->
+    <script
+      type="text/javascript"
+      src="https://oapi.map.naver.com/openapi/v3/maps.js?ncpKeyId=%VITE_NAVER_MAP_KEY%"
+    ></script>
+
     <!--
     ToDo: 완성 후 검색엔진에 노출하기 위한 메타 태그들
     <meta name="Keywords" content="여기가" />

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -14,6 +14,7 @@ import TripCalendar from './pages/TripCalendar'
 import ProtectedRoute from './components/common/ProtectedRoute'
 import UpdateCalendar from './pages/UpdateCalendar'
 import CreateNotices from './components/notice/CreateNotices'
+import PlaceMap from './pages/PlaceMap'
 
 const App = () => {
   return (
@@ -39,6 +40,7 @@ const App = () => {
                 <Route path='participation' element={<Participation />} />
                 {/* TODO: 추후 Notice 페이지와 결합 */}
                 <Route path='post/notice' element={<CreateNotices />} />
+                <Route path='map' element={<PlaceMap />} />
               </Route>
             </Route>
           </Routes>

--- a/src/components/dashboard/schedule/DateBox.jsx
+++ b/src/components/dashboard/schedule/DateBox.jsx
@@ -1,8 +1,10 @@
 import ArrowUp from '@/assets/dashboard/ArrowUp'
 import ArrowDown from '@/assets/dashboard/ArrowDown'
 import { useState } from 'react'
+import { useNavigate } from 'react-router-dom'
 
 const DateBox = ({ date }) => {
+  const navigate = useNavigate()
   const [isOpen, setIsOpen] = useState(false)
 
   const toggleOpen = () => setIsOpen((prev) => !prev)
@@ -30,7 +32,10 @@ const DateBox = ({ date }) => {
       {isOpen && (
         <div className='mt-[5px] py-10 text-center text-base text-gray-400'>
           아직 예정된 일정이 없어요
-          <div className='mt-2 cursor-pointer text-base text-[var(--Blue-Scale-blue-500)]'>
+          <div
+            onClick={() => navigate('map')}
+            className='mt-2 cursor-pointer text-base text-[var(--Blue-Scale-blue-500)]'
+          >
             + 일정 담으러 가기
           </div>
         </div>

--- a/src/pages/PlaceMap.jsx
+++ b/src/pages/PlaceMap.jsx
@@ -1,0 +1,60 @@
+import { useEffect } from 'react'
+
+/**목적지 검색을 위한 지도 화면 */
+const PlaceMap = () => {
+  useEffect(() => {
+    /**지도 생성 함수 */
+    const initMap = (lat, lng) => {
+      /**지도 옵션 설정 */
+      const mapOptions = {
+        center: new naver.maps.LatLng(lat, lng),
+        zoom: 13,
+        minZoom: 7,
+        zoomControl: true,
+        zoomControlOptions: {
+          position: naver.maps.Position.TOP_RIGHT,
+        },
+        mapTypeControl: true,
+        mapTypeControlOptions: {
+          style: naver.maps.MapTypeControlStyle.BUTTON,
+          position: naver.maps.Position.TOP_RIGHT,
+        },
+        mapTypeId: naver.maps.MapTypeId.NORMAL,
+      }
+
+      /**지도 객체 생성 */
+      const map = new naver.maps.Map('map', mapOptions)
+
+      /**마커 생성 */
+      const location = new naver.maps.LatLng(lat, lng)
+      new naver.maps.Marker({
+        position: location,
+        map,
+      })
+    }
+
+    // 현위치 가져오기
+    if (navigator.geolocation) {
+      navigator.geolocation.getCurrentPosition(
+        (position) => {
+          const { latitude, longitude } = position.coords
+          initMap(latitude, longitude)
+        },
+        (error) => {
+          console.error('위치 정보 가져오기 실패:', error)
+          initMap(37.5665, 126.978) // 실패 시 서울 시청 좌표
+        },
+      )
+    } else {
+      initMap(37.5665, 126.978)
+    }
+  }, [])
+
+  return (
+    <div className='relative h-full w-full'>
+      <div id='map' className='h-full w-full'></div>
+    </div>
+  )
+}
+
+export default PlaceMap


### PR DESCRIPTION
## 구현 배경
- [IL-242](https://ilmansa.atlassian.net/browse/IL-242)
- 여행 계획 중 목적지를 검색하여 담을 지도를 구현하기 위함

## 작업 사항
- **네이버 지도 API v3 로드(a79929cdd84e369aafb8e5ef7c710fd39c6ebf3a)**
- **지도 페이지 및 링크 추가(9788a88ada95469ebfd8c225fb9f295b953051a4)**
- **네이버 지도 API 연결 및 화면 구현(8ea2b566b2520ea6fb0334f0e511b01f47ef72f7)**
  - 초기 화면에서 현재 내 위치에 마커가 찍히도록 구현해두었습니다.
- **네이버 지도 클라이언트 ID 환경변수 추가(9698acd299bf545ab3479a77c6478fd021674872)**

## 추가 논의
- 목적지 검색 API가 브라우저에서 직접 호출할 수 없도록 되어있습니다. 우선 최초 지도 UI까지만 구현하였습니다.
- `Amplify` 환경에서는 확인이 어렵네요, 스크린샷 추가하겠습니다!
<img width="2032" height="1312" alt="스크린샷 2025-08-03 01 34 38" src="https://github.com/user-attachments/assets/7f1e988e-0bc5-42ba-ad61-dbe1d0cef3b8" />

- map 라벨도 추가해주시면 감사하겠습니다!

[IL-242]: https://ilmansa.atlassian.net/browse/IL-242?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ