### PR TITLE
Feature(IL-240): 특정 공지사항 조회 API 연동 구현

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -14,6 +14,7 @@ import TripCalendar from './pages/TripCalendar'
 import ProtectedRoute from './components/common/ProtectedRoute'
 import UpdateCalendar from './pages/UpdateCalendar'
 import CreateNotices from './components/notice/CreateNotices'
+import PastNotices from './components/notice/PastNotices'
 
 const App = () => {
   return (
@@ -39,6 +40,9 @@ const App = () => {
                 <Route path='participation' element={<Participation />} />
                 {/* TODO: 추후 Notice 페이지와 결합 */}
                 <Route path='post/notice' element={<CreateNotices />} />
+                {/* TODO: 추후 Notice 페이지와 결합 */}
+                {/* 지난 여행 전체보기 페이지 */}
+                <Route path='past/notices' element={<PastNotices />} />
               </Route>
             </Route>
           </Routes>

--- a/src/apis/notice/readSpecificNoticeApi.jsx
+++ b/src/apis/notice/readSpecificNoticeApi.jsx
@@ -1,0 +1,24 @@
+import api from '@/apis/api'
+import { prodBaseUrl } from '@/config/Env'
+
+/**특정 공지사항 조회 API */
+const readSpecificNoticeApi = async (tripId, noticeId) => {
+  try {
+    const response = await api.get(
+      `${prodBaseUrl}trip/${tripId}/notices/${noticeId}`,
+    )
+    return response.data
+  } catch (err) {
+    if (err.response?.data?.message) {
+      throw new Error(err.response.data.message)
+    } else if (err.response) {
+      throw new Error(`오류 발생 (status: ${err.response.status})`)
+    } else if (err.request) {
+      throw new Error('서버로부터 응답이 없습니다.')
+    } else {
+      throw new Error('요청 중 알 수 없는 오류가 발생했습니다.')
+    }
+  }
+}
+
+export default readSpecificNoticeApi

--- a/src/components/notice/Notices.jsx
+++ b/src/components/notice/Notices.jsx
@@ -5,14 +5,15 @@ import useAuth from '@/hooks/useAuth'
 import readNoticeApi from '@/apis/notice/readNoticeApi'
 import { useNavigate, useParams } from 'react-router-dom'
 import deleteNoticeApi from '@/apis/notice/deleteNoticeApi'
+import readSpecificNoticeApi from '@/apis/notice/readSpecificNoticeApi'
 
 const Notices = () => {
   const { user } = useAuth()
-  const { tripId } = useParams()
+  const { tripId, noticeId } = useParams()
   const navigate = useNavigate()
   const [notices, setNotices] = useState([])
-  const [selectedNoticeId, setSelectedNoticeId] = useState(null)
   const [isModalOpen, setIsModalOpen] = useState(false)
+  const [selectedNotice, setSelectedNotice] = useState(null)
 
   /**전체 공지사항 조회 API 호출 */
   useEffect(() => {
@@ -29,26 +30,15 @@ const Notices = () => {
     }
   }, [user, tripId])
 
-  /**공지사항 삭제 API 호출 */
-  const deleteNotice = async () => {
-    if (!selectedNoticeId) return
-
+  /** 특정 공지사항 조회 API 호출 */
+  const fetchSpecificNotice = async (id) => {
     try {
-      await deleteNoticeApi(tripId, selectedNoticeId)
-      alert('정상적으로 삭제되었습니다.')
-      const result = await readNoticeApi(tripId)
-      setNotices(result.data.content)
-      setIsModalOpen(false)
-      setSelectedNoticeId(null)
+      const result = await readSpecificNoticeApi(tripId, id)
+      setSelectedNotice(result.data)
+      setIsModalOpen(true)
     } catch (err) {
-      alert(err.message)
+      console.error(err)
     }
-  }
-
-  /**공지사항 클릭 시 모달 열기 */
-  const handleNoticeClick = (id) => {
-    setSelectedNoticeId(id)
-    setIsModalOpen(true)
   }
 
   /**보라색 박스 공통 스타일링 지정 */
@@ -62,31 +52,46 @@ const Notices = () => {
 
   return (
     <div className='space-y-2'>
-      {/**삭제 모달 */}
-      {/* TODO: 모달 위치 옮기기 */}
-      {isModalOpen && (
+      {/* 특정 공지사항 조회 모달 */}
+      {isModalOpen && selectedNotice && (
         <div className='fixed inset-0 z-50 flex items-center justify-center bg-black/50'>
-          <div className='h-[180px] w-[380px] rounded-2xl bg-white p-6 shadow-xl'>
-            <h3 className='mb-2 text-lg font-semibold text-gray-900'>
-              공지를 정말로 삭제하시겠어요?
-            </h3>
-            <p className='mb-4 text-sm'>삭제한 공지는 복구할 수 없어요.</p>
-            <div className='mt-10 flex gap-2'>
+          <div className='w-[400px] rounded-2xl bg-white p-6 shadow-xl'>
+            {/* 작성자 프로필 및 닉네임 */}
+            <div className='mb-4 flex items-center justify-between'>
+              <div className='flex items-center gap-3'>
+                <img
+                  src={selectedNotice.imageUrl || '/images/default_profile.png'}
+                  className='h-10 w-10 rounded-full object-cover'
+                />
+                <span className='text-sm font-medium text-gray-800'>
+                  {selectedNotice.nickname || '작성자 없음'}
+                </span>
+              </div>
+              {/* 작성일 표시 */}
+              <span className='text-xs text-gray-400'>
+                {selectedNotice.createdAt
+                  ? new Date(selectedNotice.createdAt).toLocaleString()
+                  : ''}
+              </span>
+            </div>
+            <h2 className='mb-2 text-xl font-semibold text-gray-900'>
+              {selectedNotice.title || '제목 없음'}
+            </h2>
+
+            <p className='mb-4 text-sm whitespace-pre-wrap text-gray-700'>
+              {selectedNotice.description || '내용 없음'}
+            </p>
+
+            {/* 닫기 버튼 */}
+            <div className='mt-4 flex'>
               <button
-                className={modalButtonStyle}
+                className='text-m w-full rounded-xl border-none bg-gray-100 px-4 py-3 font-bold text-gray-600'
                 onClick={() => {
                   setIsModalOpen(false)
-                  setSelectedNoticeId(null)
+                  setSelectedNotice(null)
                 }}
               >
-                취소
-              </button>
-              <button
-                className={modalButtonStyle}
-                onClick={deleteNotice}
-                style={{ color: '#FF0000' }}
-              >
-                삭제하기
+                닫기
               </button>
             </div>
           </div>
@@ -97,7 +102,10 @@ const Notices = () => {
       <div className='flex items-center justify-between'>
         <h1 className='text-3xl leading-normal font-bold'>현재 공지</h1>
         {/* TODO: 지난 공지 전체보기 버튼 연결 */}
-        <button className='mt-2 flex items-center border-none text-base text-gray-400 hover:text-gray-500'>
+        <button
+          onClick={() => navigate(`/trip/${tripId}/past/notices`)}
+          className='mt-2 flex items-center border-none text-base text-gray-400 hover:text-gray-500'
+        >
           지난 공지 전체보기
         </button>
       </div>
@@ -114,23 +122,23 @@ const Notices = () => {
         </div>
 
         {/** 공지사항 */}
-        {/* TODO: 가장 최신 공지사항 하나만 보이도록 구현(지난 공지  전체보기 구현 후) */}
         {notices.length === 0 ? (
           <div className={containerStyle}>
             <Archive className='h-6 w-6 text-[var(--Blue-Scale-blue-500)]' />
             <div className={fontStyle}>현재 공지사항 없음</div>
           </div>
         ) : (
-          notices.map((notice) => (
-            <div
-              key={notice.id}
-              className={containerStyle}
-              onClick={() => handleNoticeClick(notice.id)} // ✅ 클릭 시 모달 오픈
-            >
-              <Archive className='h-6 w-6 text-indigo-400' />
-              <div className={fontStyle}>{notice.title || '제목 없음'}</div>
+          <div
+            className={containerStyle}
+            onClick={() => fetchSpecificNotice(notices[0].id)}
+          >
+            <Archive className='h-6 w-6 text-[var(--Blue-Scale-blue-500)]' />
+            <div className='flex flex-col'>
+              <span className={fontStyle}>
+                {notices[0].title || '제목 없음'}
+              </span>
             </div>
-          ))
+          </div>
         )}
       </div>
     </div>

--- a/src/components/notice/PastNotices.jsx
+++ b/src/components/notice/PastNotices.jsx
@@ -1,0 +1,125 @@
+import readNoticeApi from '@/apis/notice/readNoticeApi'
+import deleteNoticeApi from '@/apis/notice/deleteNoticeApi'
+import { Archive } from 'lucide-react'
+import React, { useEffect, useState } from 'react'
+import { useParams } from 'react-router-dom'
+import useAuth from '@/hooks/useAuth'
+
+const PastNotices = () => {
+  const { user } = useAuth()
+  const { tripId } = useParams()
+  const [notices, setNotices] = useState([])
+  const [isModalOpen, setIsModalOpen] = useState(false)
+  const [selectedNoticeId, setSelectedNoticeId] = useState(null)
+
+  /** 전체 공지사항 불러오기 */
+  useEffect(() => {
+    if (user && tripId) {
+      const fetchNotice = async () => {
+        try {
+          const result = await readNoticeApi(tripId)
+          setNotices(result.data.content)
+        } catch (err) {
+          console.error(err)
+        }
+      }
+      fetchNotice()
+    }
+  }, [user, tripId])
+
+  /** 삭제 모달 열기 */
+  const handleNoticeClick = (id) => {
+    setSelectedNoticeId(id)
+    setIsModalOpen(true)
+  }
+
+  /** 공지사항 삭제 */
+  const deleteNotice = async () => {
+    if (!selectedNoticeId) return
+
+    try {
+      await deleteNoticeApi(tripId, selectedNoticeId)
+      alert('정상적으로 삭제되었습니다.')
+      const result = await readNoticeApi(tripId)
+      setNotices(result.data.content)
+      setIsModalOpen(false)
+      setSelectedNoticeId(null)
+    } catch (err) {
+      alert(err.message)
+    }
+  }
+
+  /** 모달 버튼 공통 스타일 */
+  const modalButtonStyle =
+    'rounded-xl bg-gray-100 text-m font-semibold text-gray-600 border-none w-1/2'
+
+  return (
+    <div className='flex w-full flex-col gap-6 bg-[var(--Grey-Scale-grey-50)] px-10 pt-10 pb-20'>
+      <h1 className='text-4xl font-bold'>지난 공지사항 전체보기</h1>
+
+      {/* 삭제 모달 */}
+      {isModalOpen && (
+        <div className='fixed inset-0 z-50 flex items-center justify-center bg-black/50'>
+          <div className='h-[180px] w-[380px] rounded-2xl bg-white p-6 shadow-xl'>
+            <h3 className='mb-2 text-lg font-semibold text-gray-900'>
+              공지를 정말로 삭제하시겠어요?
+            </h3>
+            <p className='mb-4 text-sm'>삭제한 공지는 복구할 수 없어요.</p>
+            <div className='mt-10 flex gap-2'>
+              <button
+                className={modalButtonStyle}
+                onClick={() => {
+                  setIsModalOpen(false)
+                  setSelectedNoticeId(null)
+                }}
+              >
+                취소
+              </button>
+              <button
+                className={modalButtonStyle}
+                onClick={deleteNotice}
+                style={{ color: '#FF0000' }}
+              >
+                삭제하기
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* 공지사항 리스트 */}
+      {notices.length === 0 ? (
+        <div className='mt-4 flex items-center gap-3 rounded-2xl bg-white px-4 py-5 shadow'>
+          <Archive className='h-6 w-6 text-[var(--Blue-Scale-blue-500)]' />
+          <span className='text-base font-medium text-gray-700'>
+            공지사항이 없습니다.
+          </span>
+        </div>
+      ) : (
+        <div className='space-y-4'>
+          {notices.map((notice) => (
+            <div
+              key={notice.id}
+              className='flex cursor-pointer items-center gap-3 rounded-2xl bg-white px-4 py-5 shadow'
+              onClick={() => handleNoticeClick(notice.id)}
+            >
+              <Archive className='h-6 w-6 text-indigo-400' />
+              <div className='flex flex-col'>
+                <span className='text-base font-medium text-gray-700'>
+                  {notice.title || '제목 없음'}
+                </span>
+                <span className='text-sm text-gray-400'>
+                  {notice.createdAt
+                    ? new Date(notice.createdAt).toLocaleString()
+                    : ''}
+                </span>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default PastNotices


### PR DESCRIPTION
## 구현 배경

- [IL-240](https://ilmansa.atlassian.net/browse/IL-240) 참고
- 사용자가 특정 공지사항을 조회하고자 함

## 작업 사항

- 특정 공지사항 조회 API 로직 구현
- 지난 공지 전체보기 페이지 컴포넌트 구현
  - 공지사항 삭제 모달 위치 변경(`Notices`) -> 전체 공지사항 조회하여 클릭 시 삭제(`PastNotices`)
- 대시보드 페이지에서 공지사항 클릭 시 제목, 내용, 작성자 프로필 이미지, 날짜+시간 등 조회 가능한 모달 컴포넌트 구현
- 대시보드 페이지에 있는 공지사항을 가장 최근 공지사항 기준 1개만 보이도록 구현

## 추가 논의

- 지난 공지 전체보기 페이지에서 공지사항은 **최대 10개**만 보이도록 구현되어 있는데 페이지네이션을 통해서 다음 페이지로 넘어가서 다른 공지사항도 보이게 할지? 아니면 그냥 둘 지 디자인에 따라 달라질 것 같긴한데 의논 필요할 것 같습니당 @gugitgugit 

- 모달, 지난 공지 전체보기 페이지 디자인은 추후 변경될 수 있습니당


[IL-240]: https://ilmansa.atlassian.net/browse/IL-240?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ