### PR TITLE
Feature(IL-255): 계정 복구 API 연동

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -16,6 +16,7 @@ import UpdateCalendar from './pages/UpdateCalendar'
 import CreateNotices from './components/notice/CreateNotices'
 import PastNotices from './components/notice/PastNotices'
 import PlaceMap from './pages/PlaceMap'
+import RestoreAccount from './pages/RestoreAccount'
 
 const App = () => {
   return (
@@ -28,6 +29,8 @@ const App = () => {
             <Route path='signup' element={<SignUp />} />
             <Route path='oauth/kakao/callback' element={<KakaoRedirect />} />
             <Route path='oauth/naver/callback' element={<NaverRedirect />} />
+            {/* TODO: 추후 페이지 변경 예정 */}
+            <Route path='restore/account' element={<RestoreAccount />} />
 
             {/* 보호된 비공개 라우트 */}
             <Route element={<ProtectedRoute />}>

--- a/src/apis/authentication/oauthSignInApi.jsx
+++ b/src/apis/authentication/oauthSignInApi.jsx
@@ -6,15 +6,7 @@ const oauthSignInApi = async (platform, code) => {
     const response = await api.post(`oauth/sign-in/${platform}/web`, { code })
     return response.data
   } catch (err) {
-    if (err.response?.data?.message) {
-      throw new Error(err.response.data.message)
-    } else if (err.response) {
-      throw new Error(`오류 발생 (status: ${err.response.status})`)
-    } else if (err.request) {
-      throw new Error('서버로부터 응답이 없습니다.')
-    } else {
-      throw new Error('요청 중 알 수 없는 오류가 발생했습니다.')
-    }
+    throw err
   }
 }
 

--- a/src/apis/authentication/regularSignInApi.jsx
+++ b/src/apis/authentication/regularSignInApi.jsx
@@ -8,15 +8,7 @@ const regularSignInApi = async (body) => {
     })
     return response.data
   } catch (err) {
-    if (err.response?.data?.message) {
-      throw new Error(err.response.data.message)
-    } else if (err.response) {
-      throw new Error(`오류 발생 (status: ${err.response.status})`)
-    } else if (err.request) {
-      throw new Error('서버로부터 응답이 없습니다.')
-    } else {
-      throw new Error('요청 중 알 수 없는 오류가 발생했습니다.')
-    }
+    throw err
   }
 }
 

--- a/src/apis/authentication/restoreAccountApi.jsx
+++ b/src/apis/authentication/restoreAccountApi.jsx
@@ -1,0 +1,21 @@
+import api from '@/apis/api'
+
+/**계정 복구 API */
+const restoreAccountApi = async (userId) => {
+  try {
+    const response = await api.put('auth/restore', { userId })
+    return response.data
+  } catch (err) {
+    if (err.response?.data?.message) {
+      throw new Error(err.response.data.message)
+    } else if (err.response) {
+      throw new Error(`오류 발생 (status: ${err.response.status})`)
+    } else if (err.request) {
+      throw new Error('서버로부터 응답이 없습니다.')
+    } else {
+      throw new Error('요청 중 알 수 없는 오류가 발생했습니다.')
+    }
+  }
+}
+
+export default restoreAccountApi

--- a/src/components/sign-in/KakaoRedirect.jsx
+++ b/src/components/sign-in/KakaoRedirect.jsx
@@ -9,24 +9,38 @@ const KakaoRedirect = () => {
   const { login } = useAuth()
 
   useEffect(() => {
-    const queryPrams = new URLSearchParams(location.search)
-    const code = queryPrams.get('code')
+    const queryParams = new URLSearchParams(location.search)
+    const code = queryParams.get('code')
 
     if (code) {
       fetchKakaoAccessToken(code)
     }
   }, [location])
 
-  /**카카오 소셜 로그인 호출 */
   const fetchKakaoAccessToken = async (code) => {
     try {
       const response = await oauthSignInApi('KAKAO', code)
       login({ token: response.data.token.accessToken })
       navigate('/')
     } catch (error) {
-      console.error('카카오 로그인 중 오류 발생:', error.message)
+      const errRes = error.response?.data
+      /**탈퇴 계정 로그인 시 복구 페이지로 이동 */
+      if (errRes?.data?.userId && errRes?.data?.deletionExpiration) {
+        alert('탈퇴된 계정입니다. 계정 복구 페이지로 이동합니다.')
+        navigate('/restore/account', {
+          state: {
+            userId: errRes.data.userId,
+            deletionDate: errRes.data.deletionExpiration,
+          },
+        })
+      } else {
+        alert(`로그인 실패: ${errRes?.message || err.message}`)
+        console.error('로그인 에러: ', err)
+      }
     }
   }
+
+  return null
 }
 
 export default KakaoRedirect

--- a/src/components/sign-in/NaverRedirect.jsx
+++ b/src/components/sign-in/NaverRedirect.jsx
@@ -24,7 +24,20 @@ const NaverRedirect = () => {
       login({ token: response.data.token.accessToken })
       navigate('/')
     } catch (error) {
-      console.error('네이버 로그인 중 오류 발생:', error.message)
+      const errRes = error.response?.data
+      /**탈퇴 계정 로그인 시 복구 페이지로 이동 */
+      if (errRes?.data?.userId && errRes?.data?.deletionExpiration) {
+        alert('탈퇴된 계정입니다. 계정 복구 페이지로 이동합니다.')
+        navigate('/restore/account', {
+          state: {
+            userId: errRes.data.userId,
+            deletionDate: errRes.data.deletionExpiration,
+          },
+        })
+      } else {
+        alert(`로그인 실패: ${errRes?.message || err.message}`)
+        console.error('로그인 에러: ', err)
+      }
     }
   }
 }

--- a/src/components/sign-in/SignInForm.jsx
+++ b/src/components/sign-in/SignInForm.jsx
@@ -33,8 +33,20 @@ const SignInForm = () => {
       login({ token: result.data.accessToken })
       navigate('/')
     } catch (err) {
-      alert(`로그인 실패: ${err.message}`)
-      console.error('로그인 에러: ', err)
+      const errRes = err.response?.data
+      /**탈퇴 계정 로그인 시 복구 페이지로 이동 */
+      if (errRes?.data?.userId && errRes?.data?.deletionExpiration) {
+        alert('탈퇴된 계정입니다. 계정 복구 페이지로 이동합니다.')
+        navigate('/restore/account', {
+          state: {
+            userId: errRes.data.userId,
+            deletionDate: errRes.data.deletionExpiration,
+          },
+        })
+      } else {
+        alert(`로그인 실패: ${errRes?.message || err.message}`)
+        console.error('로그인 에러: ', err)
+      }
     }
   }
 

--- a/src/pages/RestoreAccount.jsx
+++ b/src/pages/RestoreAccount.jsx
@@ -1,0 +1,40 @@
+import restoreAccountApi from '@/apis/authentication/restoreAccountApi'
+import React from 'react'
+import { useLocation, useNavigate } from 'react-router-dom'
+
+const RestoreAccount = () => {
+  const location = useLocation()
+  const navigate = useNavigate()
+  const { userId, deletionDate } = location.state || {}
+
+  /**계정 복구 API 호출 */
+  const restoreAccount = async () => {
+    try {
+      await restoreAccountApi(userId)
+      alert('계정이 복구되었습니다. 로그인 페이지로 이동합니다.')
+      navigate('/signin')
+    } catch (err) {
+      alert(err.response?.data?.message || '계정 복구에 실패했습니다.')
+    }
+  }
+
+  return (
+    // TODO: 페이지 디자인 변경
+    <div className='mx-auto max-w-md p-6 text-center'>
+      <h1 className='mb-4 text-2xl font-bold'>계정 복구 안내</h1>
+      <p className='mb-2'>이 계정은 탈퇴 처리된 상태입니다.</p>
+      <p className='mb-4 text-sm text-gray-500'>
+        <strong>{new Date(deletionDate).toLocaleString()}</strong> 이후에는
+        복구가 불가능합니다.
+      </p>
+      <button
+        onClick={restoreAccount}
+        className='rounded bg-blue-500 px-6 py-2 text-white'
+      >
+        계정 복구하기
+      </button>
+    </div>
+  )
+}
+
+export default RestoreAccount


### PR DESCRIPTION
## 구현 배경

- [IL-255](https://ilmansa.atlassian.net/browse/IL-255) 참고
- 탈퇴한 사용자가 탈퇴된 계정을 7일 이내 복구하고자 함

## 작업 사항

- 계정 복구 API 호출 및 연동
  - 소셜 로그인, 일반 로그인 같은 로직 사용
    - 서버 응답 데이터 전체를 받기 위해서 에러 전체 객체를 던지도록 코드 수정

## 추가 논의
- 계정 복구 페이지 UI 는 추후 수정(TODO)


[IL-255]: https://ilmansa.atlassian.net/browse/IL-255?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ