### PR TITLE
Feature(IL-258): 임시 저장 목적지 순서 변경

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "yeogiga-web",
       "version": "0.0.0",
       "dependencies": {
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/sortable": "^10.0.0",
+        "@dnd-kit/utilities": "^3.2.2",
         "@tailwindcss/vite": "^4.1.5",
         "axios": "^1.9.0",
         "lucide-react": "^0.535.0",
@@ -309,6 +312,59 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/sortable": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
+      "integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -3536,7 +3592,6 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "devOptional": true,
       "license": "0BSD"
     },
     "node_modules/type-check": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,9 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "@tailwindcss/vite": "^4.1.5",
     "axios": "^1.9.0",
     "lucide-react": "^0.535.0",

--- a/src/apis/dashboard/readDatePlaceApi.jsx
+++ b/src/apis/dashboard/readDatePlaceApi.jsx
@@ -1,5 +1,4 @@
 import api from '@/apis/api'
-import { prodBaseUrl } from '@/config/Env'
 
 /**일자별 목적지 조회 API */
 const readDatePlaceApi = async (tripId, day) => {

--- a/src/apis/dashboard/updatePlaceOrderApi.jsx
+++ b/src/apis/dashboard/updatePlaceOrderApi.jsx
@@ -1,0 +1,21 @@
+import api from '@/apis/api'
+
+/**일자별 목적지 순서 변경 API */
+const updatePlaceOrderApi = async (tripId, day, body) => {
+  try {
+    const response = await api.put(`trip/${tripId}/days/${day}/places`, body)
+    return response.data
+  } catch (err) {
+    if (err.response?.data?.message) {
+      throw new Error(err.response.data.message)
+    } else if (err.response) {
+      throw new Error(`오류 발생 (status: ${err.response.status})`)
+    } else if (err.request) {
+      throw new Error('서버로부터 응답이 없습니다.')
+    } else {
+      throw new Error('요청 중 알 수 없는 오류가 발생했습니다.')
+    }
+  }
+}
+
+export default updatePlaceOrderApi

--- a/src/components/dashboard/SlideTabs.jsx
+++ b/src/components/dashboard/SlideTabs.jsx
@@ -69,6 +69,10 @@ const SlideTabs = ({ isScheduleConfirmed }) => {
         onSlideChange={(swiper) => setActiveTab(swiper.activeIndex)}
         slidesPerView={1}
         spaceBetween={0}
+        allowTouchMove={true} // 전체는 허용
+        noSwiping={true}
+        noSwipingClass='no-swipe-zone' // 이 클래스 붙은 곳만 스와이프 금지
+        simulateTouch={true}
         className='w-full overflow-hidden'
       >
         <SwiperSlide className='!w-full'>

--- a/src/components/dashboard/schedule/DateBox.jsx
+++ b/src/components/dashboard/schedule/DateBox.jsx
@@ -3,20 +3,35 @@ import ArrowDown from '@/assets/dashboard/ArrowDown'
 import { useEffect, useState } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
 import readDatePlaceApi from '@/apis/dashboard/readDatePlaceApi'
+import {
+  DndContext,
+  MouseSensor,
+  TouchSensor,
+  closestCenter,
+  useSensor,
+  useSensors,
+} from '@dnd-kit/core'
+import {
+  SortableContext,
+  verticalListSortingStrategy,
+  arrayMove,
+} from '@dnd-kit/sortable'
+import SortablePlaceItem from './SortablePlaceItem'
+import updatePlaceOrderApi from '@/apis/dashboard/updatePlaceOrderApi'
 
 /**일자별 일정 박스 */
 const DateBox = ({ date, dayIndex }) => {
-  console.log(dayIndex)
-  const navigate = useNavigate()
-  /**토글 열림 여부 */
+  /**토글 여부 */
   const [isOpen, setIsOpen] = useState(false)
-  /**일자별 장소 */
+  /**일차별 장소 */
   const [places, setPlaces] = useState([])
 
+  const navigate = useNavigate()
   const { tripId } = useParams()
 
   const toggleOpen = () => setIsOpen((prev) => !prev)
 
+  /**일자별 장소 불러오기 */
   useEffect(() => {
     const fetchDatePlaces = async () => {
       try {
@@ -27,10 +42,36 @@ const DateBox = ({ date, dayIndex }) => {
       }
     }
     fetchDatePlaces()
-  }, [dayIndex])
+  }, [dayIndex, tripId])
+
+  /**드래그 종료 시 실행할 함수 */
+  const handleDragEnd = async ({ active, over }) => {
+    if (!over || active.id === over.id) return
+
+    const prev = places
+    const oldIndex = places.findIndex((p) => p.id === active.id)
+    const newIndex = places.findIndex((p) => p.id === over.id)
+
+    // 순서 바꾸기
+    const next = arrayMove(places, oldIndex, newIndex)
+    setPlaces(next)
+
+    /**API 양식에 맞게 변경 */
+    const body = {
+      orderedPlaceIds: next.map((place) => place.id),
+    }
+
+    try {
+      await updatePlaceOrderApi(tripId, dayIndex, body)
+    } catch (err) {
+      alert(err.message)
+      // 실패할 경우 롤백
+      setPlaces(prev)
+    }
+  }
 
   return (
-    <div className='w-full rounded-[20px] border border-gray-300 bg-white px-4 py-3 drop-shadow'>
+    <div className='no-swipe-zone w-full rounded-[20px] border border-gray-300 bg-white px-4 py-3 drop-shadow'>
       <div
         className='flex cursor-pointer items-center justify-between'
         onClick={toggleOpen}
@@ -50,19 +91,28 @@ const DateBox = ({ date, dayIndex }) => {
       </div>
 
       {isOpen && (
-        <div className='mt-[5px] flex flex-col gap-2 px-5 pt-10'>
+        <div className='mt-[5px] flex flex-col justify-center px-5 pt-5'>
           {places.length > 0 ? (
             <>
-              {places.map((place) => (
-                <div className='flex items-center justify-start gap-5'>
-                  <div className='flex h-10 w-10 items-center justify-center rounded-full bg-[var(--Grey-Scale-grey-100)]'>
-                    C
-                  </div>
-                  <div className='w-full rounded-2xl bg-[var(--Grey-Scale-grey-100)] p-5 text-base text-[var(--Grey-Scale-grey-300)]'>
-                    {place.name}
-                  </div>
-                </div>
-              ))}
+              <DndContext
+                collisionDetection={closestCenter}
+                onDragEnd={handleDragEnd}
+              >
+                <SortableContext
+                  items={places.map((p) => p.id)}
+                  strategy={verticalListSortingStrategy}
+                >
+                  <ul className='space-y-2'>
+                    {places.map((place) => (
+                      <SortablePlaceItem
+                        key={place.id}
+                        id={place.id}
+                        name={place.name}
+                      />
+                    ))}
+                  </ul>
+                </SortableContext>
+              </DndContext>
             </>
           ) : (
             <div className='text-center text-base text-gray-400'>

--- a/src/components/dashboard/schedule/SortablePlaceItem.jsx
+++ b/src/components/dashboard/schedule/SortablePlaceItem.jsx
@@ -1,0 +1,39 @@
+import { useSortable } from '@dnd-kit/sortable'
+import { CSS } from '@dnd-kit/utilities'
+
+/**Drag & Drop을 적용하기 위한 컴포넌트 */
+const SortablePlaceItem = ({ id, name }) => {
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id })
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.6 : 1,
+  }
+
+  return (
+    <li
+      ref={setNodeRef}
+      style={style}
+      className='flex items-center justify-start gap-5'
+      {...attributes}
+      {...listeners}
+    >
+      <div className='flex h-10 w-10 cursor-grab items-center justify-center rounded-full bg-[var(--Grey-Scale-grey-100)]'>
+        C
+      </div>
+      <div className='w-full rounded-2xl bg-[var(--Grey-Scale-grey-100)] p-5 text-base text-[var(--Grey-Scale-grey-300)]'>
+        {name}
+      </div>
+    </li>
+  )
+}
+
+export default SortablePlaceItem


### PR DESCRIPTION
## 구현 배경
- [IL-258](https://ilmansa.atlassian.net/browse/IL-258)
- 일자별로 임시로 저장(확정 전)된 목적지들의 순서를 변경하기 위함

## 작업 사항
- **`dnd-kit` 라이브러리 설치(4ba1183a16f71713b5af6f64cf1ea9689fda4d24)**
- **불필요 코드 삭제(b83970b4c9bf663b1d8aeca688907cb33d866b38)**
- **목적지 순서 변경 API 구현(b83970b4c9bf663b1d8aeca688907cb33d866b38)**
- **목적지 순서 변경 UI 및 기능 구현(8fc779bf8c7a26dfbe58d0b7952baf45a770cae4)**

## 추가 논의
- `dnd-kit` 라이브러리를 통해 Drag & Drop 방식으로 편리하게 순서를 변경할 수 있도록 구현했습니다!

[IL-258]: https://ilmansa.atlassian.net/browse/IL-258?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ