### PR TITLE
Feature(IL-278): 메인화면 내 SETTING, PLANNED 상태 여행 렌더링

### DIFF
--- a/src/components/home/PlannedTrip.jsx
+++ b/src/components/home/PlannedTrip.jsx
@@ -1,0 +1,21 @@
+import TripPreviewCard from './common/TripPreviewCard'
+
+/**준비중인 여행 목록 렌더링 */
+const PlannedTrip = ({ settingTrips = [] }) => {
+  if (!Array.isArray(settingTrips) || settingTrips.length === 0) return null
+
+  return (
+    <section className='mt-6'>
+      <h2 className='mb-3 px-1 text-lg font-bold text-gray-900'>
+        준비중인 여행
+      </h2>
+      <div className='grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-3'>
+        {settingTrips.map((trip) => (
+          <TripPreviewCard key={trip.tripId} trip={trip} />
+        ))}
+      </div>
+    </section>
+  )
+}
+
+export default PlannedTrip

--- a/src/components/home/common/TripPreviewCard.jsx
+++ b/src/components/home/common/TripPreviewCard.jsx
@@ -1,0 +1,85 @@
+import { MapPin, Calendar } from 'lucide-react'
+import { useNavigate } from 'react-router-dom'
+
+/**날짜 형식 설정을 위한 함수 */
+const formatDate = (d) =>
+  new Date(d)
+    .toLocaleDateString('ko-KR', {
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+    })
+    .replaceAll('. ', '. ')
+    .replace('.', '. ')
+
+/**시작일 기준으로 D-day 문자열 생성 함수 */
+const getDday = (start) => {
+  if (!start) return null
+  const today = new Date()
+  today.setHours(0, 0, 0, 0)
+  const s = new Date(start)
+  s.setHours(0, 0, 0, 0)
+  const diff = Math.ceil((s - today) / (1000 * 60 * 60 * 24))
+  if (diff > 0) return `D-${diff}`
+  if (diff === 0) return 'D-Day'
+  return `D+${Math.abs(diff)}`
+}
+
+/**준비중인 여행을 렌더링하기 위한 카드 */
+const TripPreviewCard = ({ trip }) => {
+  const navigate = useNavigate()
+  const dday = getDday(trip.startedAt || trip.startDate)
+
+  /** 디데이 함수 */
+  const calculateDday = (startDateString) => {
+    if (!startDateString) return 'D-??'
+    const today = new Date()
+    const startDate = new Date(startDateString)
+
+    today.setHours(0, 0, 0, 0)
+    startDate.setHours(0, 0, 0, 0)
+
+    const diffTime = startDate.getTime() - today.getTime()
+    const diffDays = Math.ceil(diffTime / (1000 * 60 * 60 * 24))
+
+    if (diffDays > 0) return `D-${diffDays}`
+    if (diffDays === 0) return 'D-Day'
+    return `D+${Math.abs(diffDays)}`
+  }
+
+  const containerStyle =
+    'flex items-center gap-3 rounded-2xl bg-[var(--Blue-Scale-blue-100)]  px-4 py-5'
+
+  return (
+    <div className='w-full rounded-2xl bg-[var(--Blue-Scale-blue-100)] px-4 py-5 text-left shadow-sm transition'>
+      {/** 상단: D-Day 배지 + 제목 */}
+
+      <div className='mb-2 flex items-center gap-3'>
+        <span className='inline-flex h-7 items-center rounded-full bg-white px-3 text-sm leading-none font-semibold text-[var(--Blue-Scale-blue-500)] shadow-sm'>
+          {calculateDday(trip.startedAt)}
+        </span>
+        <h3 className='truncate text-[20px] leading-none font-extrabold text-gray-900'>
+          {trip.title || '여행이름'}
+        </h3>
+      </div>
+
+      {/** 위치 */}
+      <div className='mt-2 flex items-center gap-2 text-[15px] text-gray-500'>
+        <MapPin className='h-5 w-5' />
+        <span>{trip.city || '아직 정해지지 않았어요'}</span>
+      </div>
+
+      {/** 기간 */}
+      <div className='mt-2 flex items-center gap-2 text-[15px] text-gray-500'>
+        <Calendar className='h-5 w-5' />
+        <span className='truncate'>
+          {trip.startedAt && trip.endedAt
+            ? `${formatDate(trip.startedAt)} - ${formatDate(trip.endedAt)}`
+            : '아직 정해지지 않았어요'}
+        </span>
+      </div>
+    </div>
+  )
+}
+
+export default TripPreviewCard

--- a/src/components/home/utils/PlannedTripSlide.jsx
+++ b/src/components/home/utils/PlannedTripSlide.jsx
@@ -1,0 +1,43 @@
+import { useRef } from 'react'
+import { Swiper, SwiperSlide } from 'swiper/react'
+import { A11y } from 'swiper/modules'
+import 'swiper/css'
+import TripPreviewCard from '@/components/home/common/TripPreviewCard'
+
+/**준비 중인 여행 목록 가로 슬라이드 */
+const PlannedTripSlide = ({ settingTrips = [] }) => {
+  if (!Array.isArray(settingTrips) || settingTrips.length === 0) return null
+  const swiperRef = useRef(null)
+
+  return (
+    <section className='mt-6 w-full'>
+      <div className='mb-3 flex items-center justify-between px-1'>
+        <h2 className='text-2xl font-bold text-gray-900'>
+          {settingTrips.length}개의 준비중인 여행
+        </h2>
+      </div>
+
+      <Swiper
+        modules={[A11y]}
+        onSwiper={(s) => (swiperRef.current = s)}
+        onBeforeDestroy={() => (swiperRef.current = null)}
+        slidesPerView={1.08}
+        spaceBetween={16}
+        slidesOffsetBefore={8}
+        slidesOffsetAfter={8}
+        centeredSlides={false}
+        className='w-full'
+      >
+        {settingTrips.map((trip) => (
+          <SwiperSlide key={trip.tripId} className='!h-auto'>
+            <div className='h-full'>
+              <TripPreviewCard trip={trip} />
+            </div>
+          </SwiperSlide>
+        ))}
+      </Swiper>
+    </section>
+  )
+}
+
+export default PlannedTripSlide

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -12,6 +12,8 @@ import TrendingPlaces from '@/components/home/TrendingPlaces'
 import useAuth from '@/hooks/useAuth'
 import { useEffect, useState } from 'react'
 import { Link, useNavigate } from 'react-router-dom'
+import PlannedTrip from '@/components/home/PlannedTrip'
+import PlannedTripSlide from '@/components/home/utils/PlannedTripSlide'
 
 const Home = () => {
   const { user, logout } = useAuth()
@@ -107,7 +109,7 @@ const Home = () => {
   return (
     <div className='flex w-full flex-col gap-15 bg-[var(--Grey-Scale-grey-50)] pt-10 pb-50 pl-10'>
       <HomeTitle user={user} />
-      {/* TODO: PLANNED or PROGRESSED 여행 존재 시 출력 */}
+      <PlannedTripSlide settingTrips={settingTrips || []} />
       <RecommendedPlaces user={user} />
       <TrendingPlaces />
       <PastTrips />


### PR DESCRIPTION
## 구현 배경

- [IL-278](https://ilmansa.atlassian.net/browse/IL-278) 참고
- 메인화면 내에서 SETTING, PLANNED 상태 여행을 확인하고자 함

## 작업 사항

-  준비중인 여행 목록 렌더링을 위한 UI 컴포넌트 구현
  - 카드 컴포넌트
  - 가로 슬라이드
   <details>
    <summary>UI 미리보기 👀</summary>
    <img width="522" height="244" alt="스크린샷 2025-08-24 오전 3 02 03" src="https://github.com/user-attachments/assets/bde7a19c-afdb-489e-9fa9-f679f81e6b64" />
</details>



[IL-278]: https://ilmansa.atlassian.net/browse/IL-278?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ