### PR TITLE
Feature(IL-336): 정산 내역 세부 조회 API 연동

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -20,6 +20,7 @@ import PlanningPlaceMap from './pages/PlanningPlaceMap'
 import SettlementAdd from './pages/SettlementAdd'
 import SettlementBook from './pages/SettlementBook'
 import TripPlaceMap from './pages/TripPlaceMap'
+import SettlementDatail from './pages/SettlementDatail'
 
 const App = () => {
   return (
@@ -50,6 +51,11 @@ const App = () => {
                 <Route path='settlementbook' element={<SettlementBook />} />
                 {/** TODO: 정산내역 추가 페이지 경로 변경 예정 */}
                 <Route path='settlement/add' element={<SettlementAdd />} />
+                {/** 정산 내역 세부 조회 페이지 */}
+                <Route
+                  path='settlement/:settlementId'
+                  element={<SettlementDatail />}
+                />
                 {/* TODO: 추후 Notice 페이지와 결합 */}
                 <Route path='post/notice' element={<CreateNotices />} />
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -20,7 +20,7 @@ import PlanningPlaceMap from './pages/PlanningPlaceMap'
 import SettlementAdd from './pages/SettlementAdd'
 import SettlementBook from './pages/SettlementBook'
 import TripPlaceMap from './pages/TripPlaceMap'
-import SettlementDatail from './pages/SettlementDatail'
+import SettlementDetail from './pages/SettlementDatail'
 
 const App = () => {
   return (
@@ -54,7 +54,7 @@ const App = () => {
                 {/** 정산 내역 세부 조회 페이지 */}
                 <Route
                   path='settlement/:settlementId'
-                  element={<SettlementDatail />}
+                  element={<SettlementDetail />}
                 />
                 {/* TODO: 추후 Notice 페이지와 결합 */}
                 <Route path='post/notice' element={<CreateNotices />} />

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -20,7 +20,7 @@ import PlanningPlaceMap from './pages/PlanningPlaceMap'
 import SettlementAdd from './pages/SettlementAdd'
 import SettlementBook from './pages/SettlementBook'
 import TripPlaceMap from './pages/TripPlaceMap'
-import SettlementDetail from './pages/SettlementDatail'
+import SettlementDetail from './pages/SettlementDetail'
 
 const App = () => {
   return (

--- a/src/apis/settlement/readSettlementApi.jsx
+++ b/src/apis/settlement/readSettlementApi.jsx
@@ -1,0 +1,21 @@
+import api from '@/apis/api'
+
+/**w정산 내역 조회 API */
+const readSettlementApi = async (tripId, settlementId) => {
+  try {
+    const response = await api.get(`trip/${tripId}/settlements/${settlementId}`)
+    return response.data
+  } catch (err) {
+    if (err.response?.data?.message) {
+      throw new Error(err.response.data.message)
+    } else if (err.response) {
+      throw new Error(`오류 발생 (status: ${err.response.status})`)
+    } else if (err.request) {
+      throw new Error('서버로부터 응답이 없습니다.')
+    } else {
+      throw new Error('요청 중 알 수 없는 오류가 발생했습니다.')
+    }
+  }
+}
+
+export default readSettlementApi

--- a/src/components/settlement/SettleSlideTabs.jsx
+++ b/src/components/settlement/SettleSlideTabs.jsx
@@ -1,0 +1,160 @@
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { useParams } from 'react-router-dom'
+import { Swiper, SwiperSlide } from 'swiper/react'
+import { Scrollbar } from 'swiper/modules'
+import 'swiper/css'
+import 'swiper/css/scrollbar'
+
+import readSettlementApi from '@/apis/settlement/readSettlementApi'
+import UnsettledList from '@/components/settlement/UnsettledList'
+import SettledList from '@/components/settlement/SettledList'
+
+const SettleSlideTabs = () => {
+  const { tripId, settlementId, userId } = useParams()
+  const currentUserId = userId ? Number(userId) : undefined
+
+  const [activeTab, setActiveTab] = useState(0)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState('')
+  const [payers, setPayers] = useState([])
+  const swiperRef = useRef(null)
+
+  /** 정산 상세 불러오기 */
+  useEffect(() => {
+    const fetchDetail = async () => {
+      try {
+        setLoading(true)
+        setError('')
+        const result = await readSettlementApi(tripId, settlementId)
+        const data = result.data
+        setPayers(Array.isArray(data?.payers) ? data.payers : [])
+      } catch (err) {
+        console.error(err)
+        setError('정산 내역을 불러오지 못했습니다.')
+      } finally {
+        setLoading(false)
+        setTimeout(() => swiperRef.current?.update(), 0)
+      }
+    }
+
+    if (tripId && settlementId) fetchDetail()
+  }, [tripId, settlementId])
+
+  /** 카운트/목록 메모 */
+  const unsettledItems = useMemo(
+    () => payers.filter((p) => !p.isCompleted),
+    [payers],
+  )
+  const settledItems = useMemo(
+    () => payers.filter((p) => Boolean(p.isCompleted)),
+    [payers],
+  )
+
+  /** Swiper 핸들러 */
+  const handleTabClick = (index) => {
+    setActiveTab(index)
+    swiperRef.current?.slideTo(index)
+  }
+  const updateSwiperHeight = () => {
+    swiperRef.current?.update()
+  }
+
+  /** 로딩/에러 처리 */
+  if (loading) {
+    return (
+      <div className='rounded-[20px] bg-white p-4 text-gray-500 shadow-sm'>
+        불러오는 중...
+      </div>
+    )
+  }
+
+  if (error) {
+    return (
+      <div className='rounded-[20px] bg-white p-4 text-red-500 shadow-sm'>
+        {error}
+      </div>
+    )
+  }
+
+  /** 탭 라벨 */
+  const tabs = [
+    { key: 'UNSETTLED', label: `미정산 ${unsettledItems.length}` },
+    { key: 'SETTLED', label: `정산 완료 ${settledItems.length}` },
+  ]
+
+  return (
+    <div className='w-full overflow-hidden'>
+      {/* 탭 바 */}
+      <div className='flex'>
+        {tabs.map((tab, index) => {
+          const isActive = activeTab === index
+          return (
+            <div
+              key={tab.key}
+              className='w-1/2 cursor-pointer select-none'
+              onClick={() => handleTabClick(index)}
+            >
+              <div
+                className='relative py-2 text-center font-medium'
+                style={{ fontSize: '20px' }}
+              >
+                <div
+                  style={{
+                    color: isActive
+                      ? 'var(--Blue-Scale-blue-500)'
+                      : 'var(--Grey-Scale-grey-300)',
+                  }}
+                >
+                  {tab.label}
+                </div>
+                <div className='absolute bottom-0 left-0 z-0 h-[4px] w-full bg-gray-100' />
+                {isActive && (
+                  <div
+                    className='absolute bottom-0 left-0 z-10 h-[4px] w-full'
+                    style={{ backgroundColor: 'var(--Blue-Scale-blue-500)' }}
+                  />
+                )}
+              </div>
+            </div>
+          )
+        })}
+      </div>
+
+      {/* 콘텐츠 */}
+      <Swiper
+        modules={[Scrollbar]}
+        autoHeight
+        onSwiper={(swiper) => (swiperRef.current = swiper)}
+        onSlideChange={(swiper) => setActiveTab(swiper.activeIndex)}
+        slidesPerView={1}
+        spaceBetween={0}
+        allowTouchMove
+        className='w-full overflow-hidden'
+      >
+        {/* 미정산 */}
+        <SwiperSlide className='!w-full'>
+          <div className='mt-5 w-full'>
+            <UnsettledList
+              items={unsettledItems}
+              currentUserId={currentUserId}
+              onContentUpdate={updateSwiperHeight}
+            />
+          </div>
+        </SwiperSlide>
+
+        {/* 정산 완료 */}
+        <SwiperSlide className='!w-full'>
+          <div className='mt-5 w-full'>
+            <SettledList
+              items={settledItems}
+              currentUserId={currentUserId}
+              onContentUpdate={updateSwiperHeight}
+            />
+          </div>
+        </SwiperSlide>
+      </Swiper>
+    </div>
+  )
+}
+
+export default SettleSlideTabs

--- a/src/components/settlement/SettledList.jsx
+++ b/src/components/settlement/SettledList.jsx
@@ -1,0 +1,84 @@
+import React, { useEffect, useMemo } from 'react'
+import { useParams } from 'react-router-dom'
+import { formatWon } from '@/hooks/settlement/formatWon'
+
+const SettledList = ({ items = [], onContentUpdate, currentUserId }) => {
+  const params = useParams()
+  const inferredCurrentUserId = useMemo(() => {
+    const uid = params.userId ? Number(params.userId) : undefined
+    return Number.isFinite(uid) ? uid : undefined
+  }, [params.userId])
+
+  const me = currentUserId ?? inferredCurrentUserId
+
+  useEffect(() => {
+    const t = setTimeout(() => onContentUpdate?.(), 0)
+    return () => clearTimeout(t)
+  }, [items, onContentUpdate])
+
+  const Avatar = ({ url, isMe }) => (
+    <div
+      className={`relative h-9 w-9 overflow-hidden rounded-full bg-gray-200 ${
+        isMe ? 'ring-2 ring-[var(--Blue-Scale-blue-500)]' : 'ring-0'
+      }`}
+    >
+      {url ? (
+        <img
+          src={url}
+          alt='프로필 이미지'
+          className='h-full w-full object-cover'
+          onLoad={() => onContentUpdate?.()}
+          onError={(e) => {
+            e.currentTarget.style.display = 'none'
+            onContentUpdate?.()
+          }}
+        />
+      ) : null}
+    </div>
+  )
+
+  if (!items.length) {
+    return (
+      <div className='px-3 py-6 text-center text-gray-500'>
+        정산 완료 내역이 없습니다.
+      </div>
+    )
+  }
+
+  return (
+    <ul className='flex flex-col gap-4 px-1'>
+      {items
+        .filter((p) => p.isCompleted)
+        .map((p) => {
+          const key = p.id ?? p.userId
+          const isMe = me != null && p.userId === me
+          return (
+            <li key={key} className='flex items-center justify-between px-2'>
+              <div className='flex items-center gap-3'>
+                <Avatar url={p.imageUrl} isMe={isMe} />
+                <div className='text-base text-gray-800'>
+                  {isMe ? '(나) ' : ''}
+                  {p.nickname}
+                </div>
+              </div>
+
+              <div className='flex items-center gap-3'>
+                <div className='min-w-[110px] text-right text-gray-800'>
+                  {formatWon(p.price)}원
+                </div>
+                {/* TODO: 취소 함수 연결 */}
+                <button
+                  type='button'
+                  className='rounded-full border border-gray-200 bg-white px-3 py-1 text-sm text-gray-700'
+                >
+                  취소
+                </button>
+              </div>
+            </li>
+          )
+        })}
+    </ul>
+  )
+}
+
+export default SettledList

--- a/src/components/settlement/SettlementBox.jsx
+++ b/src/components/settlement/SettlementBox.jsx
@@ -1,9 +1,9 @@
-// src/components/account-book/SettlementBox.jsx
 import React, { useEffect, useState } from 'react'
 import { useParams } from 'react-router-dom'
 import ArrowUp from '@/assets/dashboard/ArrowUp'
 import ArrowDown from '@/assets/dashboard/ArrowDown'
 import readTotalSettlementsApi from '@/apis/settlement/readTotalSettlementsApi'
+import { formatWon } from '@/hooks/settlement/formatWon'
 
 import SelTouristIcon from '@/assets/map/category/SelTouristIcon'
 import SelTransportIcon from '@/assets/map/category/SelTransportIcon'
@@ -46,12 +46,6 @@ const typeToIcon = (type) => {
   }
 }
 
-const formatWon = (n) =>
-  new Intl.NumberFormat('ko-KR', { maximumFractionDigits: 0 }).format(
-    Number(n) || 0,
-  )
-
-// 아바타(프로필) — imageUrl 없으면 이니셜
 const Avatar = ({ url, name, size = 18 }) => {
   const s = `${size}px`
   if (url) {
@@ -76,13 +70,7 @@ const Avatar = ({ url, name, size = 18 }) => {
   )
 }
 
-/**
- * 날짜별 정산 내역 박스
- * props:
- *  - mode: 'UNSETTLED' | 'ALL' | 'DAY'  (기본 'ALL')
- *  - date?: string  // mode === 'DAY' 일 때 표시할 'YYYY-MM-DD'
- */
-const SettlementBox = ({ mode = 'ALL', date }) => {
+const SettlementBox = ({ mode = 'ALL', date, onItemClick }) => {
   const { tripId } = useParams()
   const [loading, setLoading] = useState(false)
   const [sections, setSections] = useState([])
@@ -95,13 +83,11 @@ const SettlementBox = ({ mode = 'ALL', date }) => {
         const result = await readTotalSettlementsApi(tripId)
         const groups = extractGroups(result) // { 'YYYY-MM-DD': [...] }
 
-        // 표시할 날짜 목록 결정
         let dates = Object.keys(groups).sort((a, b) => a.localeCompare(b))
         if (mode === 'DAY' && date) {
           dates = dates.filter((d) => d === date)
         }
 
-        // 날짜별 아이템 구성
         const next = dates.map((d) => {
           let items = Array.isArray(groups[d]) ? groups[d] : []
           if (mode === 'UNSETTLED') {
@@ -110,7 +96,6 @@ const SettlementBox = ({ mode = 'ALL', date }) => {
           return { date: d, items, open: true }
         })
 
-        // 빈 섹션 제거 (예: 미정산 필터 후 0건)
         setSections(next.filter((s) => s.items.length > 0))
       } catch (e) {
         console.error(e)
@@ -176,16 +161,19 @@ const SettlementBox = ({ mode = 'ALL', date }) => {
                 const total = payers.length
                 const Icon = typeToIcon(item?.type)
                 const allDone = total > 0 && completed === total
+                const sid = item?.id ?? item?.settlementId
 
                 return (
-                  <div key={item.id} className='relative'>
+                  <div key={sid} className='relative'>
                     {/* 카테고리 아이콘: 카드 밖 + 중앙 */}
                     <div className='absolute top-1/2 left-0 -translate-y-1/2'>
                       <Icon width={24} height={24} />
                     </div>
 
-                    {/* 카드 */}
-                    <div className='relative ml-9 flex items-start justify-between rounded-[16px] bg-gray-100 px-8 py-5'>
+                    <div
+                      onClick={() => onItemClick?.(sid)}
+                      className='relative ml-9 flex items-start justify-between rounded-[16px] bg-gray-100 px-8 py-5'
+                    >
                       {/* 본문 */}
                       <div className='min-w-0 pr-16'>
                         <div className='text-[12px] text-gray-400'>

--- a/src/components/settlement/SettlementTitle.jsx
+++ b/src/components/settlement/SettlementTitle.jsx
@@ -1,0 +1,133 @@
+import { useEffect, useMemo, useState } from 'react'
+import { useParams } from 'react-router-dom'
+import readSettlementApi from '@/apis/settlement/readSettlementApi'
+import CalendarIcon from '@/assets/dashboard/CalendarIcon'
+import UserIcon from '@/assets/dashboard/UserIcon'
+import { formatWon } from '@/hooks/settlement/formatWon'
+
+import SelTouristIcon from '@/assets/map/category/SelTouristIcon'
+import SelTransportIcon from '@/assets/map/category/SelTransportIcon'
+import SelMealIcon from '@/assets/map/category/SelMealIcon'
+import SelLodgingIcon from '@/assets/map/category/SelLodgingIcon'
+import SelEtcIcon from '@/assets/map/category/SelEtcIcon'
+
+const formatDate = (date) =>
+  new Date(date).toLocaleDateString('ko-KR').replace(/. /g, '. ').slice(0, -1)
+
+const typeToIcon = (type) => {
+  switch (type) {
+    case 'TOURISM':
+      return SelTouristIcon
+    case 'TRANSPORT':
+      return SelTransportIcon
+    case 'RESTAURANT':
+      return SelMealIcon
+    case 'LODGING':
+      return SelLodgingIcon
+    case 'ETC':
+    default:
+      return SelEtcIcon
+  }
+}
+
+const typeToLabel = (type) => {
+  switch (type) {
+    case 'TOURISM':
+      return '관광지'
+    case 'TRANSPORT':
+      return '이동수단'
+    case 'RESTAURANT':
+      return '식사'
+    case 'LODGING':
+      return '숙박'
+    case 'ETC':
+    default:
+      return '기타'
+  }
+}
+
+const Avatar = ({ url, name }) => {
+  if (url) {
+    return (
+      <img
+        src={url}
+        alt={name || 'payer'}
+        className='h-[20px] w-[20px] rounded-full object-cover'
+      />
+    )
+  }
+  return <div className='h-[20px] w-[20px] rounded-full bg-gray-300' />
+}
+
+const SettlementTitle = () => {
+  const { tripId, settlementId } = useParams()
+  const [data, setData] = useState(null)
+
+  useEffect(() => {
+    const fetchDetail = async () => {
+      try {
+        const res = await readSettlementApi(tripId, settlementId)
+        setData(res?.data ?? res)
+      } catch (err) {
+        alert(err.message)
+      }
+    }
+    if (tripId && settlementId) fetchDetail()
+  }, [tripId, settlementId])
+
+  const statusText = useMemo(
+    () => (data?.isCompleted ? '정산이 완료됐어요' : '정산이 진행중이에요'),
+    [data?.isCompleted],
+  )
+
+  if (!data) return <p>정산 정보를 불러오는 중...</p>
+
+  const TypeIcon = typeToIcon(data.type)
+
+  return (
+    <div>
+      <div>
+        <div
+          className='text-[14pt]'
+          style={{ color: 'var(--Blue-Scale-blue-500)' }}
+        >
+          {statusText}
+        </div>
+
+        <div className='text-[28pt] font-bold'>{data.name}</div>
+
+        <div className='text-[28pt] font-bold'>
+          {formatWon(data.totalPrice)}원
+        </div>
+      </div>
+
+      <div className='mt-4 flex flex-col gap-y-1 text-[14pt] text-gray-700'>
+        {/* 카테고리 */}
+        <div className='flex items-center gap-2'>
+          <TypeIcon className='h-5 w-5' />
+          <span>{typeToLabel(data.type)}</span>
+        </div>
+
+        {/* 날짜 */}
+        <div className='flex items-center gap-2'>
+          <CalendarIcon className='h-5 w-5' />
+          <span>{data.date ? formatDate(data.date) : '???'}</span>
+        </div>
+
+        {/* 참여자 */}
+        <div className='flex items-center gap-2'>
+          <UserIcon className='h-5 w-5' />
+          <ul className='flex gap-1'>
+            {(data.payers ?? []).map((payer) => (
+              <li key={payer.id ?? payer.userId}>
+                <Avatar url={payer.imageUrl} name={payer.nickname} />
+              </li>
+            ))}
+          </ul>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default SettlementTitle

--- a/src/components/settlement/UnsettledList.jsx
+++ b/src/components/settlement/UnsettledList.jsx
@@ -1,0 +1,82 @@
+import React, { useEffect, useMemo } from 'react'
+import { useParams } from 'react-router-dom'
+import { formatWon } from '@/hooks/settlement/formatWon'
+
+const UnsettledList = ({ items = [], onContentUpdate, currentUserId }) => {
+  const params = useParams()
+  const inferredCurrentUserId = useMemo(() => {
+    const uid = params.userId ? Number(params.userId) : undefined
+    return Number.isFinite(uid) ? uid : undefined
+  }, [params.userId])
+
+  const me = currentUserId ?? inferredCurrentUserId
+
+  useEffect(() => {
+    const t = setTimeout(() => onContentUpdate?.(), 0)
+    return () => clearTimeout(t)
+  }, [items, onContentUpdate])
+
+  const Avatar = ({ url, isMe }) => (
+    <div
+      className={`relative h-9 w-9 overflow-hidden rounded-full bg-gray-200 ${
+        isMe ? 'ring-2 ring-[var(--Blue-Scale-blue-500)]' : 'ring-0'
+      }`}
+    >
+      {url ? (
+        <img
+          src={url}
+          alt='프로필 이미지'
+          className='h-full w-full object-cover'
+          onLoad={() => onContentUpdate?.()}
+          onError={(e) => {
+            e.currentTarget.style.display = 'none'
+            onContentUpdate?.()
+          }}
+        />
+      ) : null}
+    </div>
+  )
+
+  if (!items.length) {
+    return (
+      <div className='px-3 py-6 text-center text-gray-500'>
+        미정산 내역이 없습니다.
+      </div>
+    )
+  }
+
+  return (
+    <ul className='flex flex-col gap-4 px-1'>
+      {items.map((p) => {
+        const key = p.id ?? p.userId
+        const isMe = me != null && p.userId === me
+        return (
+          <li key={key} className='flex items-center justify-between px-2'>
+            <div className='flex items-center gap-3'>
+              <Avatar url={p.imageUrl} isMe={isMe} />
+              <div className='text-base text-gray-800'>
+                {isMe ? '(나) ' : ''}
+                {p.nickname}
+              </div>
+            </div>
+
+            <div className='flex items-center gap-3'>
+              <div className='min-w-[110px] text-right text-gray-800'>
+                {formatWon(p.price)}원
+              </div>
+              {/* TODO: 완료버튼 함수 연겵 */}
+              <button
+                type='button'
+                className='border-[var(--Blue-Scale-blue-200, #cfe0ff)] rounded-full border bg-white px-3 py-1 text-sm text-[var(--Blue-Scale-blue-500)]'
+              >
+                완료
+              </button>
+            </div>
+          </li>
+        )
+      })}
+    </ul>
+  )
+}
+
+export default UnsettledList

--- a/src/hooks/settlement/formatWon.jsx
+++ b/src/hooks/settlement/formatWon.jsx
@@ -1,0 +1,4 @@
+export const formatWon = (n) =>
+  new Intl.NumberFormat('ko-KR', { maximumFractionDigits: 0 }).format(
+    Number(n) || 0,
+  )

--- a/src/pages/SettlementBook.jsx
+++ b/src/pages/SettlementBook.jsx
@@ -14,6 +14,12 @@ const SettlementBook = () => {
   /** 뒤로 가기 버튼 */
   const handleBack = () => navigate(-1)
 
+  /** 상세 페이지 이동 */
+  const handleOpenDetail = (settlementId) => {
+    if (!settlementId) return
+    navigate(`/trip/${tripId}/settlement/${settlementId}`)
+  }
+
   return (
     <>
       <div className='flex w-full flex-col pt-5'>
@@ -31,12 +37,15 @@ const SettlementBook = () => {
           <SettlementTabs onChange={setView} />
 
           {/**날짜별 내역 박스 */}
-          <SettlementBox mode={view.key} date={view.date} />
+          <SettlementBox
+            mode={view.key}
+            date={view.date}
+            onItemClick={handleOpenDetail}
+          />
           {/**내역 추가하기 버튼 */}
           <FixedActionBar className='flex justify-center'>
             <div className='flex w-4xl items-center justify-center rounded-t-[20px] bg-white p-[20px] shadow-[0_0_4px_rgba(0,0,0,0.10)]'>
               <button
-                button
                 onClick={() => navigate(`/trip/${tripId}/settlement/add`)}
                 className='flex w-full items-center justify-center gap-2 rounded-lg border-none bg-[var(--Blue-Scale-blue-500)] p-[20px] text-2xl text-white'
               >

--- a/src/pages/SettlementDetail.jsx
+++ b/src/pages/SettlementDetail.jsx
@@ -1,0 +1,34 @@
+import KebabIcon from '@/assets/dashboard/KebabIcon'
+import GoBack from '@/assets/sign-up/GoBack'
+import SettlementTitle from '@/components/settlement/SettlementTitle'
+import SettleSlideTabs from '@/components/settlement/SettleSlideTabs'
+import React from 'react'
+import { useNavigate } from 'react-router-dom'
+
+const SettlementDetail = () => {
+  const navigate = useNavigate()
+
+  /** 뒤로 가기 버튼 */
+  const handleBack = () => {
+    navigate(-1)
+  }
+  return (
+    <>
+      <div className='flex w-full flex-col pt-5'>
+        <div className='mb-5 flex items-center justify-between px-8'>
+          <button className='border-none' onClick={handleBack}>
+            <GoBack />
+          </button>
+          {/**TODO: 케밥 아이콘 클릭 시 수정, 삭제 모달 */}
+          <KebabIcon />
+        </div>
+        <div className='flex w-full flex-col gap-5 px-10'>
+          <SettlementTitle />
+          <SettleSlideTabs />
+        </div>
+      </div>
+    </>
+  )
+}
+
+export default SettlementDetail


### PR DESCRIPTION
## 구현 배경

- [IL-336](https://ilmansa.atlassian.net/browse/IL-336) 참고 
- 사용자가 특정 정산 내역을 조회하고자 함

## 작업 사항

- 세부 정산 페이지 라우팅
- 세부 정산 내역 조회 API 연동
- 공통 컴포넌트(`formatWon`) 분리 
- 세부 정산 내역 조회를 위한 UI 구현
  <details>
  <summary>📸</summary>
  <img width="447" height="695" alt="스크린샷 2025-10-10 오전 12 27 50" src="https://github.com/user-attachments/assets/3d9273aa-a5da-4ab0-bfb3-b8542f09a46e" />
</details>


## ‼️ ‼️ 추가 논의

- 정산 완료 탭에서 참가자 오른쪽의 `취소` 버튼 클릭 시 **상태 변경 API** 가 필요할 것 같은데 추후 논의가 필요
- 위와 같은 이슈로 현재 _미정산 탭_ 의 **완료** 버튼, _정산 탭_ 의 **취소** 버튼은 현재 따로 함수 연동없이 **UI**만 구현해 둔 상태
- _케밥아이콘_ 또한 추가 API 연동 시 활성화 될 예정


[IL-336]: https://ilmansa.atlassian.net/browse/IL-336?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ