### PR TITLE
Refactor(IL-352): 정산 기능 안정성 개선 및 UX 향상

### DIFF
--- a/src/components/settlement/SettledList.jsx
+++ b/src/components/settlement/SettledList.jsx
@@ -1,15 +1,10 @@
-import React, { useEffect, useMemo } from 'react'
-import { useParams } from 'react-router-dom'
+import React, { useEffect } from 'react'
 import { formatWon } from '@/hooks/settlement/formatWon'
+import useAuth from '@/hooks/useAuth'
 
-const SettledList = ({ items = [], onContentUpdate, currentUserId }) => {
-  const params = useParams()
-  const inferredCurrentUserId = useMemo(() => {
-    const uid = params.userId ? Number(params.userId) : undefined
-    return Number.isFinite(uid) ? uid : undefined
-  }, [params.userId])
-
-  const me = currentUserId ?? inferredCurrentUserId
+const UnsettledList = ({ items = [], onContentUpdate }) => {
+  const { user } = useAuth()
+  const currentUserId = user?.userId
 
   useEffect(() => {
     const t = setTimeout(() => onContentUpdate?.(), 0)
@@ -40,45 +35,48 @@ const SettledList = ({ items = [], onContentUpdate, currentUserId }) => {
   if (!items.length) {
     return (
       <div className='px-3 py-6 text-center text-gray-500'>
-        정산 완료 내역이 없습니다.
+        미정산 내역이 없습니다.
       </div>
     )
   }
 
   return (
     <ul className='flex flex-col gap-4 px-1'>
-      {items
-        .filter((p) => p.isCompleted)
-        .map((p) => {
-          const key = p.id ?? p.userId
-          const isMe = me != null && p.userId === me
-          return (
-            <li key={key} className='flex items-center justify-between px-2'>
-              <div className='flex items-center gap-3'>
-                <Avatar url={p.imageUrl} isMe={isMe} />
-                <div className='text-base text-gray-800'>
-                  {isMe ? '(나) ' : ''}
-                  {p.nickname}
-                </div>
+      {items.map((p) => {
+        const key = p.id ?? p.userId
+        const isMe = Number(p.userId) === Number(currentUserId)
+
+        return (
+          <li key={key} className='flex items-center justify-between px-2'>
+            <div className='flex items-center gap-3'>
+              <Avatar url={p.imageUrl} isMe={isMe} />
+              <div className='text-base text-gray-800'>
+                {isMe ? (
+                  <span className='font-medium text-[var(--Blue-Scale-blue-500)]'>
+                    (나){' '}
+                  </span>
+                ) : null}
+                {p.nickname}
+              </div>
+            </div>
+
+            <div className='flex items-center gap-3'>
+              <div className='min-w-[110px] text-right text-gray-800'>
+                {formatWon(p.price)}원
               </div>
 
-              <div className='flex items-center gap-3'>
-                <div className='min-w-[110px] text-right text-gray-800'>
-                  {formatWon(p.price)}원
-                </div>
-                {/* TODO: 취소 함수 연결 */}
-                <button
-                  type='button'
-                  className='rounded-full border border-gray-200 bg-white px-3 py-1 text-sm text-gray-700'
-                >
-                  취소
-                </button>
-              </div>
-            </li>
-          )
-        })}
+              <button
+                type='button'
+                className='rounded-full border border-[var(--Blue-Scale-blue-200,#cfe0ff)] bg-white px-3 py-1 text-sm text-[var(--Blue-Scale-blue-500)]'
+              >
+                완료
+              </button>
+            </div>
+          </li>
+        )
+      })}
     </ul>
   )
 }
 
-export default SettledList
+export default UnsettledList

--- a/src/components/settlement/SettlementTabs.jsx
+++ b/src/components/settlement/SettlementTabs.jsx
@@ -2,7 +2,19 @@ import React, { useEffect, useState } from 'react'
 import { useParams } from 'react-router-dom'
 import readTotalSettlementsApi from '@/apis/settlement/readTotalSettlementsApi'
 
-const SettlementTabs = ({ onChange }) => {
+const getDayNumber = (startDateString, currentDateString) => {
+  if (!startDateString || !currentDateString) return 0
+
+  const startDate = new Date(startDateString)
+  const currentDate = new Date(currentDateString)
+
+  const diffTime = currentDate.getTime() - startDate.getTime()
+  const diffDays = Math.round(diffTime / (1000 * 60 * 60 * 24))
+
+  return diffDays + 1
+}
+
+const SettlementTabs = ({ onChange, tripStartDate }) => {
   const { tripId } = useParams()
 
   const [active, setActive] = useState('ALL')
@@ -17,11 +29,14 @@ const SettlementTabs = ({ onChange }) => {
         setLoading(true)
         const result = await readTotalSettlementsApi(tripId)
         const groups = result?.data ?? {}
-        /** 날짜 키 정렬*/
-        const keys = Object.keys(groups).sort((a, b) => a.localeCompare(b))
-        setDates(keys)
 
-        /**미정산 건수 계산*/
+        /** 날짜 키 정렬 */
+        const sortedKeys = Object.keys(groups).sort((a, b) =>
+          a.localeCompare(b),
+        )
+        setDates(sortedKeys)
+
+        /** 미정산 건수 계산 */
         const allItems = Object.values(groups).flat()
         const unsettled = allItems.filter(
           (it) => it && it.isCompleted === false,
@@ -38,18 +53,14 @@ const SettlementTabs = ({ onChange }) => {
     fetchDates()
   }, [tripId])
 
-  const handleSelect = (nextActive) => {
+  const handleSelect = (nextActive, date = null) => {
     setActive(nextActive)
     if (!onChange) return
 
-    if (nextActive === 'UNSETTLED') {
-      onChange({ key: 'UNSETTLED' })
-    } else if (nextActive === 'ALL') {
-      onChange({ key: 'ALL' })
-    } else if (typeof nextActive === 'number') {
-      const idx = nextActive // 1..N
-      const date = dates[idx - 1]
-      onChange({ key: 'DAY', dayIndex: idx, date })
+    if (nextActive === 'UNSETTLED' || nextActive === 'ALL') {
+      onChange({ key: nextActive })
+    } else if (typeof nextActive === 'number' && date) {
+      onChange({ key: 'DAY', dayIndex: nextActive, date })
     }
   }
 
@@ -61,7 +72,7 @@ const SettlementTabs = ({ onChange }) => {
   return (
     <div className='w-full'>
       <div className='flex flex-wrap gap-[6px]'>
-        {/** 미정산 내역 */}
+        {/* 미정산 내역, 여행 전체 버튼 (생략) */}
         <button
           type='button'
           onClick={() => handleSelect('UNSETTLED')}
@@ -73,7 +84,6 @@ const SettlementTabs = ({ onChange }) => {
           {!loading && unsettledCount > 0 ? ` (${unsettledCount})` : ''}
         </button>
 
-        {/** 여행 전체 */}
         <button
           type='button'
           onClick={() => handleSelect('ALL')}
@@ -84,20 +94,22 @@ const SettlementTabs = ({ onChange }) => {
           여행 전체
         </button>
 
-        {/** DAY 1 ~ N (API에서 받은 날짜 수 기준) */}
-        {dates.map((_, i) => {
-          const index = i + 1
-          const isActive = active === index
+        {/** DAY 1 ~ N (Props로 받은 실제 여행 시작일 기준) */}
+        {dates.map((date) => {
+          const dayNumber = getDayNumber(tripStartDate, date)
+          if (dayNumber <= 0) return null
+
+          const isActive = active === dayNumber
           return (
             <button
-              key={_.toString() + i}
+              key={date}
               type='button'
-              onClick={() => handleSelect(index)}
+              onClick={() => handleSelect(dayNumber, date)}
               className={`cursor-pointer rounded-full px-4 py-1 text-base ${pill(isActive)}`}
               disabled={loading}
               aria-pressed={isActive}
             >
-              DAY {index}
+              DAY {dayNumber}
             </button>
           )
         })}

--- a/src/components/settlement/UnsettledList.jsx
+++ b/src/components/settlement/UnsettledList.jsx
@@ -1,15 +1,22 @@
-import React, { useEffect, useMemo } from 'react'
+import React, { useEffect } from 'react'
 import { useParams } from 'react-router-dom'
+import useAuth from '@/hooks/useAuth'
 import { formatWon } from '@/hooks/settlement/formatWon'
 
 const UnsettledList = ({ items = [], onContentUpdate, currentUserId }) => {
+  const { user } = useAuth()
   const params = useParams()
-  const inferredCurrentUserId = useMemo(() => {
-    const uid = params.userId ? Number(params.userId) : undefined
-    return Number.isFinite(uid) ? uid : undefined
-  }, [params.userId])
 
-  const me = currentUserId ?? inferredCurrentUserId
+  let me
+  if (currentUserId != null && !Number.isNaN(Number(currentUserId))) {
+    me = Number(currentUserId)
+  } else if (user?.userId != null && !Number.isNaN(Number(user.userId))) {
+    me = Number(user.userId)
+  } else if (params.userId && !Number.isNaN(Number(params.userId))) {
+    me = Number(params.userId)
+  } else {
+    me = undefined
+  }
 
   useEffect(() => {
     const t = setTimeout(() => onContentUpdate?.(), 0)
@@ -21,6 +28,7 @@ const UnsettledList = ({ items = [], onContentUpdate, currentUserId }) => {
       className={`relative h-9 w-9 overflow-hidden rounded-full bg-gray-200 ${
         isMe ? 'ring-2 ring-[var(--Blue-Scale-blue-500)]' : 'ring-0'
       }`}
+      title={isMe ? '나' : undefined}
     >
       {url ? (
         <img
@@ -49,13 +57,19 @@ const UnsettledList = ({ items = [], onContentUpdate, currentUserId }) => {
     <ul className='flex flex-col gap-4 px-1'>
       {items.map((p) => {
         const key = p.id ?? p.userId
-        const isMe = me != null && p.userId === me
+        const uid = Number(p.userId)
+        const isMe = me != null && !Number.isNaN(uid) && uid === me
+
         return (
           <li key={key} className='flex items-center justify-between px-2'>
             <div className='flex items-center gap-3'>
               <Avatar url={p.imageUrl} isMe={isMe} />
               <div className='text-base text-gray-800'>
-                {isMe ? '(나) ' : ''}
+                {isMe ? (
+                  <span className='font-medium text-[var(--Blue-Scale-blue-500)]'>
+                    (나){' '}
+                  </span>
+                ) : null}
                 {p.nickname}
               </div>
             </div>
@@ -64,10 +78,11 @@ const UnsettledList = ({ items = [], onContentUpdate, currentUserId }) => {
               <div className='min-w-[110px] text-right text-gray-800'>
                 {formatWon(p.price)}원
               </div>
-              {/* TODO: 완료버튼 함수 연겵 */}
+
+              {/* TODO: 완료 처리 함수 연결 */}
               <button
                 type='button'
-                className='border-[var(--Blue-Scale-blue-200, #cfe0ff)] rounded-full border bg-white px-3 py-1 text-sm text-[var(--Blue-Scale-blue-500)]'
+                className='rounded-full border border-[var(--Blue-Scale-blue-200,#cfe0ff)] bg-white px-3 py-1 text-sm text-[var(--Blue-Scale-blue-500)]'
               >
                 완료
               </button>

--- a/src/pages/SettlementAdd.jsx
+++ b/src/pages/SettlementAdd.jsx
@@ -7,6 +7,7 @@ import CategorySelector from '@/components/common/CategorySelector'
 
 import readMemberApi from '@/apis/member/readMemberApi'
 import createSettlementApi from '@/apis/settlement/createSettlementApi'
+import useAuth from '@/hooks/useAuth'
 
 const pad2 = (v) => String(v).padStart(2, '0')
 const onlyDigits = (v) => String(v).replace(/[^0-9]/g, '')
@@ -129,8 +130,9 @@ const MemberSelectRow = React.memo(function MemberSelectRow({
 
 const SettlementAdd = () => {
   const navigate = useNavigate()
-  const { tripId, userId } = useParams()
-  const currentUserId = userId ? Number(userId) : null
+  const { tripId } = useParams()
+  const { user } = useAuth()
+  const currentUserId = user?.userId
 
   const [amount, setAmount] = useState('')
   const [title, setTitle] = useState('')
@@ -472,8 +474,10 @@ const SettlementAdd = () => {
             ) : (
               memberList.map((member) => {
                 const isSelected = !!selectedPayersByUserId[member.userId]
+
                 const isCurrentUser =
                   currentUserId != null && member.userId === currentUserId
+
                 const allocated = allocatedByUserId[member.userId]
                 const value = manualAmountByUserId[member.userId] ?? ''
 

--- a/src/pages/SettlementAdd.jsx
+++ b/src/pages/SettlementAdd.jsx
@@ -103,7 +103,8 @@ const SettlementAdd = () => {
     const hasTitle = !!title.trim()
     const hasAmount = !!amount
     const hasDate = !!date.y && !!date.m && !!date.d
-    return hasTitle && hasAmount && hasDate
+    const hasPayers = selectedCount > 0
+    return hasTitle && hasAmount && hasDate && hasPayers
   }, [title, amount, date, selectedCount])
 
   /* 뒤로 가기 */
@@ -212,20 +213,20 @@ const SettlementAdd = () => {
       payers = selectedMembers.map((m) => ({
         userId: m.userId,
         price: Number(manualAmountByUserId[m.userId] || 0),
-        isCompleted: true,
+        isCompleted: false,
       }))
     } else if (isEvenSplitActive) {
       payers = selectedMembers.map((m) => ({
         userId: m.userId,
         price: allocatedByUserId[m.userId] ?? 0,
-        isCompleted: true,
+        isCompleted: false,
       }))
     } else {
       const even = computeEvenAllocation(totalPrice, selectedMembers)
       payers = selectedMembers.map((m) => ({
         userId: m.userId,
         price: even[m.userId],
-        isCompleted: true,
+        isCompleted: false,
       }))
     }
 
@@ -262,12 +263,17 @@ const SettlementAdd = () => {
     navigate,
   ])
 
-  const MemberSelectRow = React.memo(function MemberSelectRow({ member }) {
-    const isCurrentUser =
-      currentUserId != null && member.userId === currentUserId
-    const isSelected = !!selectedPayersByUserId[member.userId]
-    const allocated = allocatedByUserId[member.userId]
-    const showEvenAmount = isEvenSplitActive && isSelected && allocated != null
+  const MemberSelectRow = React.memo(function MemberSelectRow({
+    member,
+    isCurrentUser,
+    isSelected,
+    isManualInput,
+    allocated,
+    value = '',
+    onChange,
+    onToggle,
+  }) {
+    const showEvenAmount = !isManualInput && isSelected && allocated != null
 
     return (
       <div className='flex items-center justify-between rounded-xl px-1 py-3'>
@@ -295,10 +301,10 @@ const SettlementAdd = () => {
                 <input
                   type='text'
                   inputMode='numeric'
-                  value={manualAmountByUserId[member.userId] ?? ''}
-                  onChange={(e) =>
-                    handleChangeManualAmount(member.userId, e.target.value)
-                  }
+                  autoComplete='off'
+                  pattern='[0-9]*'
+                  value={value}
+                  onChange={(e) => onChange(e.target.value)}
                   placeholder='금액입력'
                   className='w-[110px] appearance-none rounded-none border-none bg-transparent px-0 py-1 pr-6 text-right text-sm outline-none focus:ring-0'
                 />
@@ -314,7 +320,7 @@ const SettlementAdd = () => {
           </div>
 
           <button
-            onClick={() => toggleSelectPayer(member.userId)}
+            onClick={onToggle}
             className={`relative flex h-6 w-6 items-center justify-center rounded-full border transition-colors ${
               isSelected
                 ? 'border-[var(--Blue-Scale-blue-500)] bg-[var(--Blue-Scale-blue-500)]'
@@ -464,9 +470,27 @@ const SettlementAdd = () => {
                 여행 멤버가 없습니다.
               </div>
             ) : (
-              memberList.map((member) => (
-                <MemberSelectRow key={member.userId} member={member} />
-              ))
+              memberList.map((member) => {
+                const isSelected = !!selectedPayersByUserId[member.userId]
+                const isCurrentUser =
+                  currentUserId != null && member.userId === currentUserId
+                const allocated = allocatedByUserId[member.userId]
+                const value = manualAmountByUserId[member.userId] ?? ''
+
+                return (
+                  <MemberSelectRow
+                    key={member.userId}
+                    member={member}
+                    isCurrentUser={isCurrentUser}
+                    isSelected={isSelected}
+                    isManualInput={isManualInput}
+                    allocated={allocated}
+                    value={value}
+                    onChange={(v) => handleChangeManualAmount(member.userId, v)}
+                    onToggle={() => toggleSelectPayer(member.userId)}
+                  />
+                )
+              })
             )}
           </div>
         </div>

--- a/src/pages/SettlementAdd.jsx
+++ b/src/pages/SettlementAdd.jsx
@@ -35,6 +35,98 @@ const dateInputClass =
   'h-18 rounded-2xl bg-gray-100 px-0 text-lg text-center placeholder:text-gray-400 border-none outline-none'
 const dotStyle = 'self-end text-4xl text-gray-500'
 
+const MemberSelectRow = React.memo(function MemberSelectRow({
+  member,
+  isCurrentUser,
+  isSelected,
+  isManualInput,
+  allocated,
+  value = '',
+  onChange,
+  onToggle,
+}) {
+  const showEvenAmount = !isManualInput && isSelected && allocated != null
+
+  const handleOnChange = useCallback(
+    (e) => {
+      onChange(member.userId, e.target.value)
+    },
+    [onChange, member.userId],
+  )
+
+  const handleOnToggle = useCallback(() => {
+    onToggle(member.userId)
+  }, [onToggle, member.userId])
+
+  return (
+    <div className='flex items-center justify-between rounded-xl px-1 py-3'>
+      <div className='flex items-center gap-3'>
+        <div className='relative h-9 w-9 overflow-hidden rounded-full bg-gray-200'>
+          {member.imageUrl ? (
+            <img
+              src={member.imageUrl}
+              alt={`${member.nickname} 프로필 이미지`}
+              className='h-full w-full object-cover'
+              onError={(e) => (e.currentTarget.style.display = 'none')}
+            />
+          ) : null}
+        </div>
+        <div className='text-base text-gray-800'>
+          {isCurrentUser ? '(나) ' : ''}
+          {member.nickname}
+        </div>
+      </div>
+
+      <div className='flex items-center gap-3'>
+        <div className='min-w-[120px] text-right text-gray-800'>
+          {isManualInput && isSelected ? (
+            <div className='relative'>
+              <input
+                type='text'
+                inputMode='numeric'
+                autoComplete='off'
+                pattern='[0-9]*'
+                value={value}
+                onChange={handleOnChange}
+                placeholder='금액입력'
+                className='w-[110px] appearance-none rounded-none border-none bg-transparent px-0 py-1 pr-6 text-right text-sm outline-none focus:ring-0'
+              />
+              <span className='pointer-events-none absolute top-1/2 right-1 -translate-y-1/2 text-sm text-gray-500'>
+                원
+              </span>
+            </div>
+          ) : showEvenAmount ? (
+            `${formatWon(allocated)}원`
+          ) : (
+            ''
+          )}
+        </div>
+
+        <button
+          onClick={handleOnToggle}
+          className={`relative flex h-6 w-6 items-center justify-center rounded-full border transition-colors ${
+            isSelected
+              ? 'border-[var(--Blue-Scale-blue-500)] bg-[var(--Blue-Scale-blue-500)]'
+              : 'border-gray-300 bg-white'
+          }`}
+          aria-pressed={isSelected}
+        >
+          {isSelected && (
+            <span
+              className='block h-[10px] w-[6px] rotate-45'
+              style={{
+                borderRight: '2px solid #fff',
+                borderBottom: '2px solid #fff',
+                marginTop: '-1px',
+              }}
+            />
+          )}
+        </button>
+      </div>
+    </div>
+  )
+})
+
 const SettlementAdd = () => {
   const navigate = useNavigate()
   const { tripId, userId } = useParams()
@@ -83,7 +175,9 @@ const SettlementAdd = () => {
       } catch (err) {
         alert(err.message || '여행 멤버를 불러오지 못했습니다.')
       } finally {
-        setIsLoadingMembers(false)
+        if (isMounted) {
+          setIsLoadingMembers(false)
+        }
       }
     }
 
@@ -151,27 +245,21 @@ const SettlementAdd = () => {
           )
         }
 
-        if (
-          isManualInput &&
-          next[toggleUserId] &&
-          manualAmountByUserId[toggleUserId] == null
-        ) {
-          setManualAmountByUserId((prevManual) => ({
-            ...prevManual,
-            [toggleUserId]: '',
-          }))
+        if (isManualInput && next[toggleUserId]) {
+          setManualAmountByUserId((prevManual) => {
+            if (prevManual[toggleUserId] != null) {
+              return prevManual
+            }
+            return {
+              ...prevManual,
+              [toggleUserId]: '',
+            }
+          })
         }
-
         return next
       })
     },
-    [
-      isEvenSplitActive,
-      amount,
-      memberList,
-      isManualInput,
-      manualAmountByUserId,
-    ],
+    [isEvenSplitActive, amount, memberList, isManualInput],
   )
 
   /* 총액 변경 시 1/n 재분배 */
@@ -263,99 +351,15 @@ const SettlementAdd = () => {
     navigate,
   ])
 
-  const MemberSelectRow = React.memo(function MemberSelectRow({
-    member,
-    isCurrentUser,
-    isSelected,
-    isManualInput,
-    allocated,
-    value = '',
-    onChange,
-    onToggle,
-  }) {
-    const showEvenAmount = !isManualInput && isSelected && allocated != null
-
-    return (
-      <div className='flex items-center justify-between rounded-xl px-1 py-3'>
-        <div className='flex items-center gap-3'>
-          <div className='relative h-9 w-9 overflow-hidden rounded-full bg-gray-200'>
-            {member.imageUrl ? (
-              <img
-                src={member.imageUrl}
-                alt={`${member.nickname} 프로필 이미지`}
-                className='h-full w-full object-cover'
-                onError={(e) => (e.currentTarget.style.display = 'none')}
-              />
-            ) : null}
-          </div>
-          <div className='text-base text-gray-800'>
-            {isCurrentUser ? '(나) ' : ''}
-            {member.nickname}
-          </div>
-        </div>
-
-        <div className='flex items-center gap-3'>
-          <div className='min-w-[120px] text-right text-gray-800'>
-            {isManualInput && isSelected ? (
-              <div className='relative'>
-                <input
-                  type='text'
-                  inputMode='numeric'
-                  autoComplete='off'
-                  pattern='[0-9]*'
-                  value={value}
-                  onChange={(e) => onChange(e.target.value)}
-                  placeholder='금액입력'
-                  className='w-[110px] appearance-none rounded-none border-none bg-transparent px-0 py-1 pr-6 text-right text-sm outline-none focus:ring-0'
-                />
-                <span className='pointer-events-none absolute top-1/2 right-1 -translate-y-1/2 text-sm text-gray-500'>
-                  원
-                </span>
-              </div>
-            ) : showEvenAmount ? (
-              `${formatWon(allocated)}원`
-            ) : (
-              ''
-            )}
-          </div>
-
-          <button
-            onClick={onToggle}
-            className={`relative flex h-6 w-6 items-center justify-center rounded-full border transition-colors ${
-              isSelected
-                ? 'border-[var(--Blue-Scale-blue-500)] bg-[var(--Blue-Scale-blue-500)]'
-                : 'border-gray-300 bg-white'
-            }`}
-            aria-pressed={isSelected}
-          >
-            {isSelected && (
-              <span
-                className='block h-[10px] w-[6px] rotate-45'
-                style={{
-                  borderRight: '2px solid #fff',
-                  borderBottom: '2px solid #fff',
-                  marginTop: '-1px',
-                }}
-              />
-            )}
-          </button>
-        </div>
-      </div>
-    )
-  })
-
   return (
     <div className='flex w-full flex-col pt-5'>
-      {/* 상단: 뒤로가기 */}
       <div className='mb-5 flex items-center justify-between px-8'>
         <button className='border-none' onClick={handleBack}>
           <GoBack />
         </button>
       </div>
 
-      {/* 폼 */}
       <div className='space-y-6 px-10'>
-        {/* 정산 비용 */}
         <div>
           <div className={sectionTitleClass}>정산 비용</div>
           <div className='relative'>
@@ -373,7 +377,6 @@ const SettlementAdd = () => {
           </div>
         </div>
 
-        {/* 내역 이름 */}
         <div>
           <div className={sectionTitleClass}>내역 이름</div>
           <input
@@ -385,7 +388,6 @@ const SettlementAdd = () => {
           />
         </div>
 
-        {/* 날짜 */}
         <div>
           <div className={sectionTitleClass}>날짜</div>
           <div className='flex items-center gap-2'>
@@ -427,13 +429,11 @@ const SettlementAdd = () => {
           </div>
         </div>
 
-        {/* 카테고리 */}
         <div>
           <div className={sectionTitleClass}>카테고리</div>
           <CategorySelector value={category} onChange={setCategory} size={50} />
         </div>
 
-        {/* 정산 인원 */}
         <div className='mt-4'>
           <div className='mb-2 flex items-center justify-between pr-3'>
             <div className='text-xl text-gray-800'>
@@ -486,8 +486,8 @@ const SettlementAdd = () => {
                     isManualInput={isManualInput}
                     allocated={allocated}
                     value={value}
-                    onChange={(v) => handleChangeManualAmount(member.userId, v)}
-                    onToggle={() => toggleSelectPayer(member.userId)}
+                    onChange={handleChangeManualAmount}
+                    onToggle={toggleSelectPayer}
                   />
                 )
               })
@@ -496,7 +496,6 @@ const SettlementAdd = () => {
         </div>
       </div>
 
-      {/* 확인 버튼 */}
       <FixedActionBar className='flex justify-center'>
         <div className='flex w-4xl items-center justify-center rounded-t-[20px] bg-white p-[20px] shadow-[0_0_4px_rgba(0,0,0,0.10)]'>
           <button

--- a/src/pages/SettlementBook.jsx
+++ b/src/pages/SettlementBook.jsx
@@ -3,46 +3,67 @@ import FixedActionBar from '@/components/common/FixedActionBar'
 import SettlementBox from '@/components/settlement/SettlementBox'
 import SettlementTabs from '@/components/settlement/SettlementTabs'
 import UnsettledTitle from '@/components/settlement/UnsettledTitle'
-import React, { useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
+import readTripInfoApi from '@/apis/trip/readTripInfo'
 
 const SettlementBook = () => {
   const { tripId } = useParams()
   const navigate = useNavigate()
   const [view, setView] = useState({ key: 'ALL' })
+  const [tripInfo, setTripInfo] = useState(null)
+  const [loading, setLoading] = useState(true)
 
-  /** 뒤로 가기 버튼 */
+  /** 여행 정보 불러오기 */
+  useEffect(() => {
+    const fetchTripData = async () => {
+      if (!tripId) return
+      try {
+        setLoading(true)
+        const response = await readTripInfoApi(tripId)
+        setTripInfo(response.data)
+      } catch (error) {
+        console.error('여행 정보를 불러오는 데 실패했습니다:', error)
+        navigate(-1)
+      } finally {
+        setLoading(false)
+      }
+    }
+    fetchTripData()
+  }, [tripId, navigate])
+
   const handleBack = () => navigate(-1)
-
-  /** 상세 페이지 이동 */
   const handleOpenDetail = (settlementId) => {
     if (!settlementId) return
     navigate(`/trip/${tripId}/settlement/${settlementId}`)
   }
 
+  if (loading) {
+    return <div>여행 정보를 불러오는 중입니다...</div>
+  }
+
   return (
     <>
       <div className='flex w-full flex-col pt-5'>
-        {/**뒤로가기 버튼이 있는 상단 */}
         <div className='mb-5 flex items-center justify-between px-8'>
           <button className='border-none' onClick={handleBack}>
             <GoBack />
           </button>
         </div>
-        {/**타이틀 및 슬라이딩 날짜 및 내역 탭 */}
         <div className='flex w-full flex-col gap-8 px-10'>
-          {/**타이틀*/}
           <UnsettledTitle />
-          {/**미정산 내역 및 날짜 탭 */}
-          <SettlementTabs onChange={setView} />
+          {tripInfo?.startedAt && (
+            <SettlementTabs
+              onChange={setView}
+              tripStartDate={tripInfo.startedAt}
+            />
+          )}
 
-          {/**날짜별 내역 박스 */}
           <SettlementBox
             mode={view.key}
             date={view.date}
             onItemClick={handleOpenDetail}
           />
-          {/**내역 추가하기 버튼 */}
           <FixedActionBar className='flex justify-center'>
             <div className='flex w-4xl items-center justify-center rounded-t-[20px] bg-white p-[20px] shadow-[0_0_4px_rgba(0,0,0,0.10)]'>
               <button


### PR DESCRIPTION
## 구현 배경

- [IL-352](https://ilmansa.atlassian.net/browse/IL-352) 참고
- 가계부 관련 버그를 수정하고 UX를 개선하고자 함

## 작업 사항


  <details>
  <summary>이전 문제점</summary>
  - DAY 번호가 정산 생성 순서에 따라 바뀜 <br/>
  - 여행 기간 밖 날짜도 DAY로 인식됨 <br/>
  - 여행 시작일 기준 일자차이 계산X <br/>
  - 정산 금액 직접 입력에 포커스 유실 버그
     => input에 금액을 한 글자 입력할 때마가 포커스가 사라져서 연속적 입력 및 삭제 불가능
  </details>

- **DAY 탭 렌더링 로직 개선**
  - API를 통해 자식 컴포넌트에 props로 전달하고 이를 기준으로 DAY 번호 계산
  - 여행 기간 외 날짜는 `여행 전체` 탭을 통해 확인 가능
- **정산 금액 직접 입력 시 포커스 유실 버그 수정**
  -  `MemberSelectRow` 컴포넌트를 부모 컴포넌트`SettlementAdd` 외부로 **분리**
  -  `toggleSelectPayer` 함수에서 불필요한 함수 재생이 일어나지 않도록 수정
- **사용자의 닉네임 앞에 (나) 표시 기능 추가**
  - `useAuth` 훅으로 사용자 식별


[IL-352]: https://ilmansa.atlassian.net/browse/IL-352?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ