### PR TITLE
Feature(IL-350): 정산 내역 삭제 API 연동

### DIFF
--- a/src/apis/settlement/deleteSettlementApi.jsx
+++ b/src/apis/settlement/deleteSettlementApi.jsx
@@ -1,0 +1,23 @@
+import api from '@/apis/api'
+
+/**정산 삭제 API */
+const deleteSettlementApi = async (tripId, settlementId) => {
+  try {
+    const response = await api.delete(
+      `trip/${tripId}/settlements/${settlementId}`,
+    )
+    return response.data
+  } catch (err) {
+    if (err.response?.data?.message) {
+      throw new Error(err.response.data.message)
+    } else if (err.response) {
+      throw new Error(`오류 발생 (status: ${err.response.status})`)
+    } else if (err.request) {
+      throw new Error('서버로부터 응답이 없습니다.')
+    } else {
+      throw new Error('요청 중 알 수 없는 오류가 발생했습니다.')
+    }
+  }
+}
+
+export default deleteSettlementApi

--- a/src/components/dashboard/modal/SettlementDeleteConfirmModal.jsx
+++ b/src/components/dashboard/modal/SettlementDeleteConfirmModal.jsx
@@ -1,0 +1,68 @@
+import React, { useEffect } from 'react'
+import { createPortal } from 'react-dom'
+
+const SettlementDeleteConfirmModal = ({
+  open,
+  title = '정산 내역',
+  onCancel,
+  onConfirm,
+}) => {
+  // ESC + 스크롤락
+  useEffect(() => {
+    if (!open) return
+    const onKey = (e) => e.key === 'Escape' && onCancel?.()
+    document.addEventListener('keydown', onKey)
+
+    const original = document.body.style.overflow
+    document.body.style.overflow = 'hidden'
+    return () => {
+      document.body.style.overflow = original || ''
+      document.removeEventListener('keydown', onKey)
+    }
+  }, [open, onCancel])
+
+  if (!open) return null
+
+  return createPortal(
+    <div className='fixed inset-0 z-[9999] flex items-center justify-center'>
+      {/* 배경 */}
+      <div
+        className='absolute inset-0 bg-black/50'
+        onClick={onCancel}
+        aria-hidden='true'
+      />
+      {/* 카드 */}
+      <div
+        className='relative z-10 w-[380px] rounded-2xl bg-white p-6 shadow-xl'
+        role='dialog'
+        aria-modal='true'
+        onClick={(e) => e.stopPropagation()}
+      >
+        <h2 className='mb-2 text-lg font-bold text-gray-900'>
+          “{title}” 내역을 정말로 삭제하시겠어요?
+        </h2>
+        <p className='mb-10 text-sm text-gray-500'>
+          해당 작업은 복구할 수 없어요
+        </p>
+
+        <div className='flex gap-2'>
+          <button
+            className='flex-1 rounded-lg border-none bg-gray-100 py-3 font-semibold text-gray-700'
+            onClick={onCancel}
+          >
+            취소
+          </button>
+          <button
+            className='flex-1 rounded-lg border-none bg-gray-100 py-3 font-semibold text-red-500'
+            onClick={onConfirm}
+          >
+            삭제하기
+          </button>
+        </div>
+      </div>
+    </div>,
+    document.body,
+  )
+}
+
+export default SettlementDeleteConfirmModal

--- a/src/components/settlement/SettlementTitle.jsx
+++ b/src/components/settlement/SettlementTitle.jsx
@@ -12,7 +12,7 @@ import SelLodgingIcon from '@/assets/map/category/SelLodgingIcon'
 import SelEtcIcon from '@/assets/map/category/SelEtcIcon'
 
 const formatDate = (date) =>
-  new Date(date).toLocaleDateString('ko-KR').replace(/. /g, '. ').slice(0, -1)
+  new Date(date).toLocaleDateString('ko-KR').replace(/\.\s/g, '. ').slice(0, -1)
 
 const typeToIcon = (type) => {
   switch (type) {
@@ -59,15 +59,15 @@ const Avatar = ({ url, name }) => {
   return <div className='h-[20px] w-[20px] rounded-full bg-gray-300' />
 }
 
-const SettlementTitle = () => {
+const SettlementTitle = ({ onTitleReady }) => {
   const { tripId, settlementId } = useParams()
   const [data, setData] = useState(null)
 
   useEffect(() => {
     const fetchDetail = async () => {
       try {
-        const res = await readSettlementApi(tripId, settlementId)
-        setData(res?.data ?? res)
+        const result = await readSettlementApi(tripId, settlementId)
+        setData(result.data)
       } catch (err) {
         alert(err.message)
       }
@@ -75,9 +75,21 @@ const SettlementTitle = () => {
     if (tripId && settlementId) fetchDetail()
   }, [tripId, settlementId])
 
+  useEffect(() => {
+    if (
+      data &&
+      typeof data.name === 'string' &&
+      data.name.length > 0 &&
+      typeof onTitleReady === 'function'
+    ) {
+      onTitleReady(data.name)
+    }
+  }, [data, onTitleReady])
+
   const statusText = useMemo(
-    () => (data?.isCompleted ? '정산이 완료됐어요' : '정산이 진행중이에요'),
-    [data?.isCompleted],
+    () =>
+      data && data.isCompleted ? '정산이 완료됐어요' : '정산이 진행중이에요',
+    [data],
   )
 
   if (!data) return <p>정산 정보를 불러오는 중...</p>
@@ -118,7 +130,7 @@ const SettlementTitle = () => {
         <div className='flex items-center gap-2'>
           <UserIcon className='h-5 w-5' />
           <ul className='flex gap-1'>
-            {(data.payers ?? []).map((payer) => (
+            {(Array.isArray(data.payers) ? data.payers : []).map((payer) => (
               <li key={payer.id ?? payer.userId}>
                 <Avatar url={payer.imageUrl} name={payer.nickname} />
               </li>

--- a/src/pages/SettlementDetail.jsx
+++ b/src/pages/SettlementDetail.jsx
@@ -3,27 +3,52 @@ import GoBack from '@/assets/sign-up/GoBack'
 import SettlementTitle from '@/components/settlement/SettlementTitle'
 import SettleSlideTabs from '@/components/settlement/SettleSlideTabs'
 import React, { useState } from 'react'
-import { useNavigate } from 'react-router-dom'
+import { useNavigate, useParams } from 'react-router-dom'
 import SettlementOptionsModal from '@/components/dashboard/modal/SettlementOptionsModal'
+import deleteSettlementApi from '@/apis/settlement/deleteSettlementApi'
+import SettlementDeleteConfirmModal from '@/components/dashboard/modal/SettlementDeleteConfirmModal'
+
 const SettlementDetail = () => {
   const navigate = useNavigate()
-  const [isOptionsOpen, setIsOptionsOpen] = useState(false)
+  const { tripId, settlementId } = useParams()
 
-  /** 뒤로 가기 */
+  const [isOptionsOpen, setIsOptionsOpen] = useState(false)
+  const [isDeleteConfirmOpen, setIsDeleteConfirmOpen] = useState(false)
+  const [settlementTitle, setSettlementTitle] = useState('정산 내역')
+
+  const handleTitleReady = (title) => {
+    if (title) setSettlementTitle(title)
+  }
+
   const handleBack = () => navigate(-1)
 
-  /**TODO: 옵션 모달 관련 핸들러 연결 */
   const handleEdit = () => {
     setIsOptionsOpen(false)
-    // TODO: 수정 화면 이동 등
+    // TODO: 수정 화면 이동
   }
+
   const handleDelete = () => {
     setIsOptionsOpen(false)
-    // TODO: 삭제 confirm 모달/로직
+    setIsDeleteConfirmOpen(true)
   }
+
   const handleReannounce = () => {
     setIsOptionsOpen(false)
     // TODO: 재공지 로직
+  }
+
+  /** 정산 내역 삭제 API 호출 */
+  const confirmDeleteSettlement = async () => {
+    try {
+      await deleteSettlementApi(tripId, settlementId)
+      alert('정산 내역이 삭제되었습니다.')
+      navigate(-1)
+    } catch (err) {
+      console.error(err)
+      alert('정산 내역 삭제에 실패했습니다.')
+    } finally {
+      setIsDeleteConfirmOpen(false)
+    }
   }
 
   return (
@@ -33,8 +58,6 @@ const SettlementDetail = () => {
           <button className='border-none' onClick={handleBack}>
             <GoBack />
           </button>
-
-          {/** 케밥 아이콘 클릭 시 옵션 모달 오픈 */}
           <button
             type='button'
             className='border-none bg-transparent p-1'
@@ -44,20 +67,23 @@ const SettlementDetail = () => {
             <KebabIcon />
           </button>
         </div>
-
         <div className='flex w-full flex-col gap-5 px-10'>
-          <SettlementTitle />
+          <SettlementTitle onTitleReady={handleTitleReady} />
           <SettleSlideTabs />
         </div>
       </div>
-
-      {/** 바텀시트 옵션 모달 */}
       <SettlementOptionsModal
         open={isOptionsOpen}
         onClose={() => setIsOptionsOpen(false)}
         onEdit={handleEdit}
         onDelete={handleDelete}
         onReannounce={handleReannounce}
+      />
+      <SettlementDeleteConfirmModal
+        open={isDeleteConfirmOpen}
+        title={settlementTitle}
+        onCancel={() => setIsDeleteConfirmOpen(false)}
+        onConfirm={confirmDeleteSettlement}
       />
     </>
   )


### PR DESCRIPTION
## 구현 배경

- [IL-350](https://ilmansa.atlassian.net/browse/IL-350) 참고
- 사용자가 자신의 정산 내역을 삭제하고자 함

## 작업 사항

- 정산 내역 삭제 API 연동
  - 로직 및 호출 구현
  - 삭제 모달 구현
    - `SettlementTitle`에서 정산 내역 제목 상위 컴포넌트로 전달 기능 추가
 - 옵셔널 체이닝 제거 리팩토링
   - 코드 안정성 향상

[IL-350]: https://ilmansa.atlassian.net/browse/IL-350?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ