### PR TITLE
Feature(IL-366): 임시 목적지 추가 요청에 주소 필드 추가

### DIFF
--- a/src/components/dashboard/TripTitle.jsx
+++ b/src/components/dashboard/TripTitle.jsx
@@ -51,10 +51,14 @@ const TripTitle = ({ isScheduleConfirmed, setIsScheduleConfirmed }) => {
         <div className='text-[28pt] font-bold'>{tripInfo.title}</div>
       </div>
 
-      <div className='mt-4 flex flex-col gap-y-1 text-[14pt] text-gray-700'>
+      <div className='mt-4 flex flex-col gap-y-1 text-[14pt] text-[var(--Grey-Scale-grey-300)]'>
         <div className='flex items-center gap-2'>
           <PinIcon className='h-5 w-5' />
-          <div>{tripInfo.city || '???'}</div>
+          <div>
+            {tripInfo.city.length > 0
+              ? tripInfo.city.join(', ')
+              : '아직 확정된 목적지가 없습니다.'}
+          </div>
         </div>
         <div className='flex items-center gap-2'>
           <CalendarIcon className='h-5 w-5' />

--- a/src/components/dashboard/schedule/SortablePlaceItem.jsx
+++ b/src/components/dashboard/schedule/SortablePlaceItem.jsx
@@ -41,8 +41,8 @@ const SortablePlaceItem = ({ id, place, onContextMenu }) => {
   }
 
   const isVisited = place.isVisited ?? false
-  const Icon = categoryIcons[place.placeType] || EtcIcon
-  const color = categoryColors[place.placeType] || '#C161EE'
+  const Icon = categoryIcons[place.placeCategory] || EtcIcon
+  const color = categoryColors[place.placeCategory] || '#C161EE'
 
   return (
     <li

--- a/src/components/dashboard/schedule/SortablePlaceItem.jsx
+++ b/src/components/dashboard/schedule/SortablePlaceItem.jsx
@@ -41,8 +41,8 @@ const SortablePlaceItem = ({ id, place, onContextMenu }) => {
   }
 
   const isVisited = place.isVisited ?? false
-  const Icon = categoryIcons[place.placeCategory] || EtcIcon
-  const color = categoryColors[place.placeCategory] || '#C161EE'
+  const Icon = categoryIcons[place.placeType] || EtcIcon
+  const color = categoryColors[place.placeType] || '#C161EE'
 
   return (
     <li

--- a/src/components/home/PastTrips.jsx
+++ b/src/components/home/PastTrips.jsx
@@ -45,7 +45,11 @@ const PastTrips = ({ pastTrips = [], loadMore }) => {
                   </h3>
                   <div className='flex items-center gap-2 text-lg'>
                     <MapPin className='h-5 w-5' />
-                    <span>{trip.city || '미정'}</span>
+                    <span>
+                      {trip.city.length > 0
+                        ? trip.city.join(', ')
+                        : '아직 정해지지 않았어요'}
+                    </span>
                   </div>
                   <div className='mb-1 flex items-center gap-2 text-lg'>
                     <Calendar className='h-5 w-5' />

--- a/src/components/home/common/TripPreviewCard.jsx
+++ b/src/components/home/common/TripPreviewCard.jsx
@@ -46,7 +46,11 @@ const TripPreviewCard = ({ trip }) => {
       {/** 위치 */}
       <div className='mt-2 flex items-center gap-2 text-[15px] text-gray-500'>
         <MapPin className='h-5 w-5' />
-        <span>{trip.city || '아직 정해지지 않았어요'}</span>
+        <span>
+          {trip.city.length > 0
+            ? trip.city.join(', ')
+            : '아직 정해지지 않았어요'}
+        </span>
       </div>
 
       {/** 기간 */}

--- a/src/components/mypage/AllTrips.jsx
+++ b/src/components/mypage/AllTrips.jsx
@@ -45,7 +45,11 @@ const AllTrips = ({ allTrips = [], loadMore }) => {
                   </h3>
                   <div className='flex items-center gap-2 text-lg'>
                     <MapPin className='h-5 w-5' />
-                    <span>{trip.city || '미정'}</span>
+                    <span>
+                      {trip.city.length > 0
+                        ? trip.city.join(', ')
+                        : '아직 정해지지 않았어요'}
+                    </span>
                   </div>
                   <div className='mb-1 flex items-center gap-2 text-lg'>
                     <Calendar className='h-5 w-5' />
@@ -54,7 +58,7 @@ const AllTrips = ({ allTrips = [], loadMore }) => {
                         ? `${formatDate(trip.startedAt)} - ${formatDate(
                             trip.endedAt,
                           )}`
-                        : '미정'}
+                        : '아직 정해지지 않았어요'}
                     </span>
                   </div>
                   <div className='flex items-center gap-2'>

--- a/src/pages/PlaceMap.jsx
+++ b/src/pages/PlaceMap.jsx
@@ -14,7 +14,7 @@ import CategorySelector from '@/components/common/CategorySelector'
 const PlaceMap = () => {
   const navigate = useNavigate()
   /** 선택된 카테고리 */
-  const [placeType, setPlaceType] = useState('ETC')
+  const [placeType, setPlaceType] = useState('TOURISM')
 
   /**검색어 */
   const [keyword, setKeyword] = useState('')
@@ -162,7 +162,7 @@ const PlaceMap = () => {
         ...prev,
         {
           ...selectedPlace,
-          chosenType: placeType === 'TRANSPORT' ? 'ETC' : placeType || 'ETC',
+          placeType: placeType,
         },
       ])
       alert('목적지가 임시 저장되었습니다.')
@@ -178,10 +178,10 @@ const PlaceMap = () => {
     for (const place of savedPlaces) {
       const body = {
         name: place.title || place.name,
+        address: place.roadAddress || place.address,
         latitude: place.latitude,
         longitude: place.longitude,
-        placeType:
-          place.chosenType === 'TRANSPORT' ? 'ETC' : place.chosenType || 'ETC',
+        placeType: place.placeType,
       }
 
       try {


### PR DESCRIPTION
## 구현 배경
- [IL-366](https://ilmansa.atlassian.net/browse/IL-366)
- 여행의 `city` 필드를 위해 새로운 주소 필드 추가

## 작업 사항
- **API request body에 `Address` 필드 추가(4b14eea2417228906889035899da8aa7f2d503b6)**
  - 기본적으로 도로명주소 사용, 없을 시 일반 주소 사용
- **목적지 UI 렌더링 조건 수정(3211c72cdf9bd05575b73da6ad89568aa93bd918)**
  - `city` 필드가 비어있을 경우 기존 `null` 에서 `[]`로 바뀌어 조건을 변경했습니다.

## 추가 논의

- 구현 중 발생한 이슈
- 추가로 하고 싶은 말


[IL-366]: https://ilmansa.atlassian.net/browse/IL-366?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ