### PR TITLE
Feature(IL-349): 정산 완료 여부 갱신 API 연동

### DIFF
--- a/src/apis/settlement/patchSettlementApi.jsx
+++ b/src/apis/settlement/patchSettlementApi.jsx
@@ -1,0 +1,24 @@
+import api from '@/apis/api'
+
+/** 정산 내역 상태 변경 API */
+const patchSettlementApi = async (tripId, settlementId, body) => {
+  try {
+    const response = await api.patch(
+      `trip/${tripId}/settlements/${settlementId}`,
+      body,
+    )
+    return response.data
+  } catch (err) {
+    if (err.response?.data?.message) {
+      throw new Error(err.response.data.message)
+    } else if (err.response) {
+      throw new Error(`오류 발생 (status: ${err.response.status})`)
+    } else if (err.request) {
+      throw new Error('서버로부터 응답이 없습니다.')
+    } else {
+      throw new Error('요청 중 알 수 없는 오류가 발생했습니다.')
+    }
+  }
+}
+
+export default patchSettlementApi

--- a/src/components/settlement/SettledList.jsx
+++ b/src/components/settlement/SettledList.jsx
@@ -1,61 +1,86 @@
-import React, { useEffect } from 'react'
-import { formatWon } from '@/hooks/settlement/formatWon'
+import React, { useState, useCallback } from 'react'
+import { useParams } from 'react-router-dom'
 import useAuth from '@/hooks/useAuth'
+import { formatWon } from '@/hooks/settlement/formatWon'
+import patchSettlementApi from '@/apis/settlement/patchSettlementApi'
 
-const UnsettledList = ({ items = [], onContentUpdate }) => {
+const SettledList = ({ items = [] }) => {
   const { user } = useAuth()
-  const currentUserId = user?.userId
+  const { tripId, settlementId } = useParams()
+  const [loadingId, setLoadingId] = useState(null)
+  const tripIdNum = Number(tripId)
+  const settlementIdNum = Number(settlementId)
+  const currentUserId = Number(user?.userId)
 
-  useEffect(() => {
-    const t = setTimeout(() => onContentUpdate?.(), 0)
-    return () => clearTimeout(t)
-  }, [items, onContentUpdate])
-
-  const Avatar = ({ url, isMe }) => (
-    <div
-      className={`relative h-9 w-9 overflow-hidden rounded-full bg-gray-200 ${
-        isMe ? 'ring-2 ring-[var(--Blue-Scale-blue-500)]' : 'ring-0'
-      }`}
-    >
-      {url ? (
-        <img
-          src={url}
-          alt='프로필 이미지'
-          className='h-full w-full object-cover'
-          onLoad={() => onContentUpdate?.()}
-          onError={(e) => {
-            e.currentTarget.style.display = 'none'
-            onContentUpdate?.()
-          }}
-        />
-      ) : null}
-    </div>
+  /**정산 완료 처리 API 연동 */
+  const handleSettlementAction = useCallback(
+    async (item) => {
+      if (loadingId) return
+      const payInfoId = Number(item.payInfoId ?? item.id)
+      const ok = window.confirm(`${item.nickname}님의 정산을 취소하시겠습니까?`)
+      if (!ok) return
+      setLoadingId(payInfoId)
+      try {
+        await patchSettlementApi(tripIdNum, settlementIdNum, {
+          payInfos: [{ payInfoId, isCompleted: false }],
+        })
+        alert(`${item.nickname}님의 정산이 취소되었습니다.`)
+        window.location.reload()
+      } catch (err) {
+        console.error(err)
+        alert(err?.message || '정산 취소 처리 중 오류가 발생했습니다.')
+      } finally {
+        setLoadingId(null)
+      }
+    },
+    [loadingId, tripIdNum, settlementIdNum],
   )
 
   if (!items.length) {
     return (
       <div className='px-3 py-6 text-center text-gray-500'>
-        미정산 내역이 없습니다.
+        정산 완료된 내역이 없습니다.
       </div>
     )
   }
 
+  const Avatar = ({ url, isMe }) => (
+    <div
+      className={`relative h-9 w-9 overflow-hidden rounded-full bg-gray-200 ${
+        isMe ? 'ring-2 ring-[var(--Blue-Scale-blue-500)]' : ''
+      }`}
+    >
+      {url && (
+        <img
+          src={url}
+          alt='프로필 이미지'
+          className='h-full w-full object-cover'
+          onError={(e) => {
+            e.currentTarget.style.display = 'none'
+          }}
+        />
+      )}
+    </div>
+  )
+
   return (
     <ul className='flex flex-col gap-4 px-1'>
       {items.map((p) => {
-        const key = p.id ?? p.userId
-        const isMe = Number(p.userId) === Number(currentUserId)
+        const payInfoId = Number(p.payInfoId ?? p.id)
+        const key = `pay-${payInfoId}`
+        const isMe = Number(p.userId) === currentUserId
+        const isLoading = loadingId === payInfoId
 
         return (
           <li key={key} className='flex items-center justify-between px-2'>
             <div className='flex items-center gap-3'>
               <Avatar url={p.imageUrl} isMe={isMe} />
               <div className='text-base text-gray-800'>
-                {isMe ? (
+                {isMe && (
                   <span className='font-medium text-[var(--Blue-Scale-blue-500)]'>
                     (나){' '}
                   </span>
-                ) : null}
+                )}
                 {p.nickname}
               </div>
             </div>
@@ -67,9 +92,15 @@ const UnsettledList = ({ items = [], onContentUpdate }) => {
 
               <button
                 type='button'
-                className='rounded-full border border-[var(--Blue-Scale-blue-200,#cfe0ff)] bg-white px-3 py-1 text-sm text-[var(--Blue-Scale-blue-500)]'
+                onClick={() => handleSettlementAction(p)}
+                disabled={isLoading}
+                className={`rounded-full border border-[var(--Blue-Scale-blue-200,#cfe0ff)] bg-white px-3 py-1 text-sm transition-all ${
+                  isLoading
+                    ? 'cursor-not-allowed opacity-60'
+                    : 'text-[var(--Blue-Scale-blue-500)] hover:bg-[var(--Blue-Scale-blue-50)]'
+                }`}
               >
-                완료
+                취소
               </button>
             </div>
           </li>
@@ -79,4 +110,4 @@ const UnsettledList = ({ items = [], onContentUpdate }) => {
   )
 }
 
-export default UnsettledList
+export default SettledList

--- a/src/components/settlement/SettlementTitle.jsx
+++ b/src/components/settlement/SettlementTitle.jsx
@@ -29,7 +29,6 @@ const typeToIcon = (type) => {
       return SelEtcIcon
   }
 }
-
 const typeToLabel = (type) => {
   switch (type) {
     case 'TOURISM':
@@ -46,18 +45,16 @@ const typeToLabel = (type) => {
   }
 }
 
-const Avatar = ({ url, name }) => {
-  if (url) {
-    return (
-      <img
-        src={url}
-        alt={name || 'payer'}
-        className='h-[20px] w-[20px] rounded-full object-cover'
-      />
-    )
-  }
-  return <div className='h-[20px] w-[20px] rounded-full bg-gray-300' />
-}
+const Avatar = ({ url, name }) =>
+  url ? (
+    <img
+      src={url}
+      alt={name || 'payer'}
+      className='h-[20px] w-[20px] rounded-full object-cover'
+    />
+  ) : (
+    <div className='h-[20px] w-[20px] rounded-full bg-gray-300' />
+  )
 
 const SettlementTitle = ({ onTitleReady }) => {
   const { tripId, settlementId } = useParams()
@@ -76,20 +73,26 @@ const SettlementTitle = ({ onTitleReady }) => {
   }, [tripId, settlementId])
 
   useEffect(() => {
-    if (
-      data &&
-      typeof data.name === 'string' &&
-      data.name.length > 0 &&
-      typeof onTitleReady === 'function'
-    ) {
+    if (data?.name && typeof onTitleReady === 'function')
       onTitleReady(data.name)
-    }
   }, [data, onTitleReady])
 
+  const allCompleted = useMemo(() => {
+    if (!data) return false
+    if (Array.isArray(data.payInfos) && data.payInfos.length > 0) {
+      return data.payInfos.every((pi) => pi?.isCompleted === true)
+    }
+    if (Array.isArray(data.payers) && data.payers.length > 0) {
+      return data.payers.every(
+        (p) => p?.isCompleted === true || p?.completed === true,
+      )
+    }
+    return Boolean(data.isCompleted)
+  }, [data])
+
   const statusText = useMemo(
-    () =>
-      data && data.isCompleted ? '정산이 완료됐어요' : '정산이 진행중이에요',
-    [data],
+    () => (allCompleted ? '정산이 완료됐어요' : '정산이 진행중이에요'),
+    [allCompleted],
   )
 
   if (!data) return <p>정산 정보를 불러오는 중...</p>
@@ -106,27 +109,34 @@ const SettlementTitle = ({ onTitleReady }) => {
           {statusText}
         </div>
 
-        <div className='text-[28pt] font-bold'>{data.name}</div>
+        <div
+          className={`text-[30pt] font-bold transition-opacity ${
+            allCompleted ? 'text-gray-400 opacity-80' : 'text-black opacity-100'
+          }`}
+        >
+          {data.name}
+        </div>
 
-        <div className='text-[28pt] font-bold'>
+        <div
+          className={`text-[30pt] font-bold transition-opacity ${
+            allCompleted ? 'text-gray-400 opacity-80' : 'text-black opacity-100'
+          }`}
+        >
           {formatWon(data.totalPrice)}원
         </div>
       </div>
 
       <div className='mt-4 flex flex-col gap-y-1 text-[14pt] text-gray-700'>
-        {/* 카테고리 */}
         <div className='flex items-center gap-2'>
           <TypeIcon className='h-5 w-5' />
           <span>{typeToLabel(data.type)}</span>
         </div>
 
-        {/* 날짜 */}
         <div className='flex items-center gap-2'>
           <CalendarIcon className='h-5 w-5' />
           <span>{data.date ? formatDate(data.date) : '???'}</span>
         </div>
 
-        {/* 참여자 */}
         <div className='flex items-center gap-2'>
           <UserIcon className='h-5 w-5' />
           <ul className='flex gap-1'>

--- a/src/components/settlement/UnsettledList.jsx
+++ b/src/components/settlement/UnsettledList.jsx
@@ -1,75 +1,103 @@
-import React, { useEffect } from 'react'
+import React, { useState, useCallback } from 'react'
 import { useParams } from 'react-router-dom'
 import useAuth from '@/hooks/useAuth'
 import { formatWon } from '@/hooks/settlement/formatWon'
+import patchSettlementApi from '@/apis/settlement/patchSettlementApi'
 
-const UnsettledList = ({ items = [], onContentUpdate, currentUserId }) => {
+const UnsettledList = ({ items = [], currentUserId }) => {
   const { user } = useAuth()
-  const params = useParams()
+  const { tripId, settlementId, userId: routeUserId } = useParams()
+  const [loadingId, setLoadingId] = useState(null)
 
-  let me
-  if (currentUserId != null && !Number.isNaN(Number(currentUserId))) {
-    me = Number(currentUserId)
-  } else if (user?.userId != null && !Number.isNaN(Number(user.userId))) {
-    me = Number(user.userId)
-  } else if (params.userId && !Number.isNaN(Number(params.userId))) {
-    me = Number(params.userId)
-  } else {
-    me = undefined
-  }
+  const tripIdNum = Number(tripId)
+  const settlementIdNum = Number(settlementId)
 
-  useEffect(() => {
-    const t = setTimeout(() => onContentUpdate?.(), 0)
-    return () => clearTimeout(t)
-  }, [items, onContentUpdate])
+  /** 현재 로그인 사용자 식별 */
+  const me =
+    Number(currentUserId) ||
+    Number(user?.userId) ||
+    Number(routeUserId) ||
+    undefined
+
+  /**정산 완료 처리 API 연동 */
+  const handleSettlementAction = useCallback(
+    async (item) => {
+      if (loadingId) return
+
+      const payInfoId = Number(item.payInfoId ?? item.id)
+      if (!payInfoId) {
+        alert('유효하지 않은 결제 항목입니다.')
+        return
+      }
+
+      const ok = window.confirm(
+        `${item.nickname}님의 정산을 완료 처리하시겠습니까?`,
+      )
+      if (!ok) return
+
+      setLoadingId(payInfoId)
+
+      try {
+        await patchSettlementApi(tripIdNum, settlementIdNum, {
+          payInfos: [{ payInfoId, isCompleted: true }],
+        })
+        alert(`${item.nickname}님의 정산이 완료 처리되었습니다.`)
+        window.location.reload()
+      } catch (err) {
+        console.error(err)
+        alert(err?.message || '정산 완료 처리 중 오류가 발생했습니다.')
+      } finally {
+        setLoadingId(null)
+      }
+    },
+    [tripIdNum, settlementIdNum, loadingId],
+  )
 
   const Avatar = ({ url, isMe }) => (
     <div
       className={`relative h-9 w-9 overflow-hidden rounded-full bg-gray-200 ${
-        isMe ? 'ring-2 ring-[var(--Blue-Scale-blue-500)]' : 'ring-0'
+        isMe ? 'ring-2 ring-[var(--Blue-Scale-blue-500)]' : ''
       }`}
       title={isMe ? '나' : undefined}
     >
-      {url ? (
+      {url && (
         <img
           src={url}
           alt='프로필 이미지'
           className='h-full w-full object-cover'
-          onLoad={() => onContentUpdate?.()}
           onError={(e) => {
             e.currentTarget.style.display = 'none'
-            onContentUpdate?.()
           }}
         />
-      ) : null}
+      )}
     </div>
   )
 
-  if (!items.length) {
+  if (!items.length)
     return (
       <div className='px-3 py-6 text-center text-gray-500'>
         미정산 내역이 없습니다.
       </div>
     )
-  }
 
   return (
     <ul className='flex flex-col gap-4 px-1'>
       {items.map((p) => {
-        const key = p.id ?? p.userId
-        const uid = Number(p.userId)
-        const isMe = me != null && !Number.isNaN(uid) && uid === me
+        const payInfoId = Number(p.payInfoId ?? p.id)
+        const key = `pay-${payInfoId}`
+        const isMe = Number(p.userId) === me
+        const isLoading = loadingId === payInfoId
 
         return (
           <li key={key} className='flex items-center justify-between px-2'>
             <div className='flex items-center gap-3'>
               <Avatar url={p.imageUrl} isMe={isMe} />
               <div className='text-base text-gray-800'>
-                {isMe ? (
+                {isMe && (
                   <span className='font-medium text-[var(--Blue-Scale-blue-500)]'>
                     (나){' '}
                   </span>
-                ) : null}
+                )}
                 {p.nickname}
               </div>
             </div>
@@ -79,10 +107,15 @@ const UnsettledList = ({ items = [], onContentUpdate, currentUserId }) => {
                 {formatWon(p.price)}원
               </div>
 
-              {/* TODO: 완료 처리 함수 연결 */}
               <button
                 type='button'
-                className='rounded-full border border-[var(--Blue-Scale-blue-200,#cfe0ff)] bg-white px-3 py-1 text-sm text-[var(--Blue-Scale-blue-500)]'
+                onClick={() => handleSettlementAction(p)}
+                disabled={isLoading}
+                className={`rounded-full border border-[var(--Blue-Scale-blue-200,#cfe0ff)] bg-white px-3 py-1 text-sm transition-all ${
+                  isLoading
+                    ? 'cursor-not-allowed opacity-60'
+                    : 'text-[var(--Blue-Scale-blue-500)] hover:bg-[var(--Blue-Scale-blue-50)]'
+                }`}
               >
                 완료
               </button>


### PR DESCRIPTION
## 구현 배경

- [IL-349](https://ilmansa.atlassian.net/browse/IL-349) 참고
- 사용자가 정산 완료/미완료 상태를 처리하고자 함

## 작업 사항

- 정산 완료 여부 갱신 API 로직 구현 및 연동
  - 미정산 탭에서 `완료` 버튼 클릭 시 해당 API 호출  => `isCompleted: true`
  - 정산 탭에서 `취소` 버튼 클릭 시 해당 API 호출 => `isCompleted: false`
- 전체 사용자 정산 완료 시 제목 및 금액 dimmed 처리
<img width="437" height="395" alt="스크린샷 2025-10-30 오후 6 16 23" src="https://github.com/user-attachments/assets/09fe4e54-cc50-466b-b908-1690b5e7bbc0" />


[IL-349]: https://ilmansa.atlassian.net/browse/IL-349?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ