### PR TITLE
Refact(IL-379): 아이콘 컴포넌트 외부 스타일 제어 가능하도록 수정

### DIFF
--- a/src/assets/dashboard/modal/ShareIcon.jsx
+++ b/src/assets/dashboard/modal/ShareIcon.jsx
@@ -1,11 +1,9 @@
 import React from 'react'
 
 /** 공유 아이콘 */
-const ShareIcon = ({ className }) => {
+const ShareIcon = ({ className, stroke = 'currentColor' }) => {
   return (
     <svg
-      width='44'
-      height='46'
       viewBox='0 0 20 22'
       fill='none'
       xmlns='http://www.w3.org/2000/svg'
@@ -13,7 +11,7 @@ const ShareIcon = ({ className }) => {
     >
       <path
         d='M6.59 12.51L13.42 16.49M13.41 5.51L6.59 9.49M19 4C19 5.65685 17.6569 7 16 7C14.3431 7 13 5.65685 13 4C13 2.34315 14.3431 1 16 1C17.6569 1 19 2.34315 19 4ZM7 11C7 12.6569 5.65685 14 4 14C2.34315 14 1 12.6569 1 11C1 9.34315 2.34315 8 4 8C5.65685 8 7 9.34315 7 11ZM19 18C19 19.6569 17.6569 21 16 21C14.3431 21 13 19.6569 13 18C13 16.3431 14.3431 15 16 15C17.6569 15 19 16.3431 19 18Z'
-        stroke='var(--Blue-Scale-blue-500)'
+        stroke={stroke}
         strokeWidth='2'
         strokeLinecap='round'
         strokeLinejoin='round'

--- a/src/components/dashboard/modal/KebabModal.jsx
+++ b/src/components/dashboard/modal/KebabModal.jsx
@@ -101,7 +101,7 @@ const KebabModal = ({ onClose, onOpenUpdateModal }) => {
             </button>
 
             <button onClick={copyInviteLink} className={buttonStyle}>
-              <ShareIcon />
+              <ShareIcon className='h-[22px] w-[20px]' />
               링크공유로 초대하기
             </button>
           </div>

--- a/src/pages/Participation.jsx
+++ b/src/pages/Participation.jsx
@@ -62,7 +62,10 @@ const Participation = () => {
             <div className='mx-auto flex w-full max-w-[420px] flex-col items-center text-center'>
               <div className='mb-4 grid h-40 w-40 place-items-center rounded-full bg-[rgba(113,97,255,0.08)]'>
                 <div className='grid h-30 w-30 place-items-center rounded-full bg-[rgba(113,97,255,0.12)]'>
-                  <ShareIcon />
+                  <ShareIcon
+                    className='h-12 w-12'
+                    stroke='var(--Blue-Scale-blue-500)'
+                  />
                 </div>
               </div>
 


### PR DESCRIPTION
## 구현 배경

- [IL-379](https://ilmansa.atlassian.net/browse/IL-379) 참고
- 기존 작업사항으로 ShareIcon 내부의 고정된 스타일링으로 비정상 표시 확인

## 작업 사항

- 불필요한 하드코딩 제거로 재사용성 및 확장성 개선
- 외부에서 className과 stroke 속성으로 크기 및 색상 제어 가능하도록 리팩터링

[IL-379]: https://ilmansa.atlassian.net/browse/IL-379?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ