### PR TITLE
Feature(IL-381): 닉네임 기반 기본 프로필 이미지 생성 기능 추가

### DIFF
--- a/src/apis/api.jsx
+++ b/src/apis/api.jsx
@@ -2,6 +2,7 @@ import { baseUrl } from '@/config/Env'
 import axios from 'axios'
 import reissueAccessTokenApi from '@/apis/authentication/reissueAccessTokenApi'
 import { callLogout } from '@/apis/authentication/logoutHandler'
+import { deepNormalizeUsers } from '@/components/mypage/utils/NormalizeUser'
 
 /**axios 공통 API 인스턴스 */
 const api = axios.create({
@@ -30,7 +31,14 @@ export const setUpInterceptors = () => {
 
   /**토큰 만료 시 refresh Token을 이용하여 Access Token 재발급 */
   api.interceptors.response.use(
-    (response) => response,
+    (response) => {
+      try {
+        if (response?.data) deepNormalizeUsers(response.data)
+      } catch (e) {
+        console.warn('avatar normalize error', e)
+      }
+      return response
+    },
     async (error) => {
       const originalRequest = error.config
       if (error.response?.status === 401 && !originalRequest._retry) {

--- a/src/components/mypage/ProfileCard.jsx
+++ b/src/components/mypage/ProfileCard.jsx
@@ -5,26 +5,53 @@ import naverLogoImg from '@/assets/mypage/naverIcon.png'
 const ProfileCard = ({ userInfo, onProfileClick }) => {
   const provider = localStorage.getItem('provider')
 
+  /** 닉네임 앞 두 글자 추출 */
+  const nicknameInitials = userInfo?.nickname
+    ? userInfo.nickname.slice(0, 2)
+    : ''
+
+  /** 닉네임 기반 색상 생성 함수 */
+  const getStableColor = (name) => {
+    if (!name) return '#FFFFFF'
+    let hash = 0
+    for (let i = 0; i < name.length; i++) {
+      hash = name.charCodeAt(i) + ((hash << 5) - hash)
+    }
+    const hue = Math.abs(hash) % 360
+    const saturation = 70
+    const lightness = 55
+    return `hsl(${hue}, ${saturation}%, ${lightness}%)`
+  }
+
+  const stableColor = getStableColor(userInfo?.nickname)
+
   return (
     <div className='mx-10 flex h-[160px] w-[800px] items-center rounded-[20px] border border-gray-100 bg-white px-5 shadow-sm'>
-      <div className='mr-8 aspect-square w-35 overflow-hidden rounded-full bg-gray-100'>
-        <img
-          src={userInfo.imageUrl || '/images/default_profile.png'}
-          alt='프로필'
-          className='h-full w-full rounded-full object-cover'
-        />
+      <div className='mr-8 flex aspect-square w-35 items-center justify-center overflow-hidden rounded-full bg-gray-100'>
+        {userInfo.imageUrl ? (
+          <img
+            src={userInfo.imageUrl}
+            alt='프로필'
+            className='h-full w-full rounded-full object-cover'
+          />
+        ) : (
+          <span
+            className='flex h-full w-full items-center justify-center rounded-full text-3xl font-bold text-white'
+            style={{ backgroundColor: stableColor }}
+          >
+            {nicknameInitials}
+          </span>
+        )}
       </div>
+
       <div className='flex w-full flex-col justify-center'>
         <div className='mb-2 flex items-center gap-1'>
-          {/** 소셜 로그인 로고 */}
           {provider === 'KAKAO' && (
             <img src={kakaoLogoImg} alt='Kakao' className='h-7 w-auto' />
           )}
           {provider === 'NAVER' && (
             <img src={naverLogoImg} alt='Naver' className='h-7 w-auto' />
           )}
-
-          {/** 닉네임 */}
           <span className='text-3xl font-bold text-gray-900'>
             {userInfo.nickname}
           </span>

--- a/src/components/mypage/utils/Avatar.jsx
+++ b/src/components/mypage/utils/Avatar.jsx
@@ -1,0 +1,69 @@
+/** 닉네임 앞 두 글자(없으면 'user') */
+export const getInitials = (nickname = '') => {
+  const v = nickname.trim()
+  if (!v) return 'user'
+  return v.slice(0, 2).toUpperCase()
+}
+
+/** 닉네임 HSL 색 */
+export const getStableColor = (name = '') => {
+  const n = name.trim().toLowerCase()
+  if (!n) return 'hsl(0, 0%, 100%)'
+  let hash = 0
+  for (let i = 0; i < n.length; i++) {
+    hash = n.charCodeAt(i) + ((hash << 5) - hash)
+  }
+  const hue = Math.abs(hash) % 360
+  return `hsl(${hue}, 70%, 55%)`
+}
+
+/** 배경색에 따른 텍스트 색상 */
+export const textColorForBg = (hsl) => {
+  const m = /hsl\((\d+),\s*(\d+)%\s*,\s*(\d+)%\)/i.exec(hsl)
+  if (!m) return '#fff'
+  const L = Number(m[3]) / 100
+  return L > 0.6 ? '#111' : '#fff'
+}
+
+/** 닉네임 기반 원형 아바타 SVG 문자열 */
+export const createAvatarSvg = ({
+  nickname = '',
+  size = 256,
+  fontFamily = 'system-ui, -apple-system, Segoe UI, Roboto, "Noto Sans KR", sans-serif',
+} = {}) => {
+  const initials = getInitials(nickname)
+  const bg = getStableColor(nickname)
+  const fg = textColorForBg(bg)
+  const fontSize = Math.round(size * 0.28)
+  const cx = size / 2
+
+  return `
+<svg xmlns="http://www.w3.org/2000/svg" width="${size}" height="${size}" viewBox="0 0 ${size} ${size}" role="img" aria-label="${initials}">
+  <defs>
+    <style>
+      .t {
+        font: ${fontSize}px ${fontFamily};
+        font-weight: 700;
+        text-anchor: middle;
+        dominant-baseline: middle;
+      }
+    </style>
+  </defs>
+  <circle cx="${cx}" cy="${cx}" r="${cx}" fill="${bg}"/>
+  <g transform="translate(${cx} ${cx})">
+    <text class="t" fill="${fg}" dy=".04em">${initials}</text>
+  </g>
+</svg>`.trim()
+}
+
+export const getAvatarDataUrl = ({
+  nickname = '',
+  size = 256,
+  fontFamily,
+} = {}) => {
+  const svg = createAvatarSvg({ nickname, size, fontFamily })
+  const encoded = encodeURIComponent(svg)
+    .replace(/'/g, '%27')
+    .replace(/"/g, '%22')
+  return `data:image/svg+xml;charset=utf-8,${encoded}`
+}

--- a/src/components/mypage/utils/NormalizeUser.jsx
+++ b/src/components/mypage/utils/NormalizeUser.jsx
@@ -1,4 +1,4 @@
-import { getAvatarDataUrl } from './avatar'
+import { getAvatarDataUrl } from './Avatar'
 
 /** 단일 사용자 객체 표준화 */
 export const normalizeUser = (u, { avatarSize = 256 } = {}) => {

--- a/src/components/mypage/utils/NormalizeUser.jsx
+++ b/src/components/mypage/utils/NormalizeUser.jsx
@@ -1,0 +1,38 @@
+import { getAvatarDataUrl } from './avatar'
+
+/** 단일 사용자 객체 표준화 */
+export const normalizeUser = (u, { avatarSize = 256 } = {}) => {
+  if (!u || typeof u !== 'object') return u
+  const hasNickname = typeof u.nickname === 'string' && u.nickname.trim() !== ''
+  const hasImage = !!u.imageUrl
+  if (!hasImage && hasNickname) {
+    u.imageUrl = getAvatarDataUrl({ nickname: u.nickname, size: avatarSize })
+  }
+  return u
+}
+/** 모든 사용자 객체 표준화 */
+export const deepNormalizeUsers = (data, opts = {}) => {
+  const seen = new WeakSet()
+
+  const walk = (node) => {
+    if (node && typeof node === 'object') {
+      if (seen.has(node)) return node
+      seen.add(node)
+
+      if ('nickname' in node) normalizeUser(node, opts)
+
+      if (Array.isArray(node)) {
+        for (let i = 0; i < node.length; i++) {
+          node[i] = walk(node[i])
+        }
+      } else {
+        for (const k of Object.keys(node)) {
+          node[k] = walk(node[k])
+        }
+      }
+    }
+    return node
+  }
+
+  return walk(data)
+}


### PR DESCRIPTION
## 구현 배경

- [IL-381](https://ilmansa.atlassian.net/browse/IL-381) 참고
- 프로필 이미지 설정을 하지 않은 사용자의 경우, 서비스 내 사용자 간 구분이 어려움

## 작업 사항

- 사용자 이미지가 없을 경우 닉네임 앞글자로 대체 표시되도록 구현
- 닉네임 앞글자의 배경색을 유저별 고정 랜덤 컬러로 지정
- 기본 프로필 이미지를 서비스 전역에서 사용하기 위한 로직 추가
  - axios response interceptor에 deepNormalizeUsers 적용 
  - 닉네임 기반 avatar SVG 생성 유틸 추가
  - API 응답 내 모든 사용자 객체 탐색 및 normalize하는 유틸 추가
<img width="639" height="288" alt="스크린샷 2025-11-08 오후 4 33 24" src="https://github.com/user-attachments/assets/ad4015b7-708d-4eb4-be37-0da3729e373f" />
<img width="286" height="172" alt="스크린샷 2025-11-08 오후 4 33 49" src="https://github.com/user-attachments/assets/cd3a7cd2-cf27-4216-a342-f9aa5f05acfd" />

## 추가 논의
- 위 이미지 보시다시피 일반로그인임에도 카카오로그인 아이콘이 보이는 오류가 있는데 이 부분 수정하겠습니다

[IL-381]: https://ilmansa.atlassian.net/browse/IL-381?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ