### PR TITLE
Feature(IL-380): 내 정산만 보기 및 미정산 내역 필터 로직 개선

### DIFF
--- a/src/components/settlement/SettlementBox.jsx
+++ b/src/components/settlement/SettlementBox.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react'
+import React, { useEffect, useState, useMemo } from 'react'
 import { useParams } from 'react-router-dom'
 import ArrowUp from '@/assets/dashboard/ArrowUp'
 import ArrowDown from '@/assets/dashboard/ArrowDown'
@@ -70,10 +70,11 @@ const Avatar = ({ url, name, size = 18 }) => {
   )
 }
 
-const SettlementBox = ({ mode = 'ALL', date, onItemClick }) => {
+const SettlementBox = ({ mode, date, onItemClick, filterUserId, myUserId }) => {
   const { tripId } = useParams()
   const [loading, setLoading] = useState(false)
   const [sections, setSections] = useState([])
+  const [openMap, setOpenMap] = useState({})
 
   useEffect(() => {
     if (!tripId) return
@@ -81,7 +82,7 @@ const SettlementBox = ({ mode = 'ALL', date, onItemClick }) => {
       try {
         setLoading(true)
         const result = await readTotalSettlementsApi(tripId)
-        const groups = extractGroups(result) // { 'YYYY-MM-DD': [...] }
+        const groups = extractGroups(result)
 
         let dates = Object.keys(groups).sort((a, b) => a.localeCompare(b))
         if (mode === 'DAY' && date) {
@@ -93,10 +94,19 @@ const SettlementBox = ({ mode = 'ALL', date, onItemClick }) => {
           if (mode === 'UNSETTLED') {
             items = items.filter((it) => it && it.isCompleted === false)
           }
-          return { date: d, items, open: true }
+          return { date: d, items }
         })
 
-        setSections(next.filter((s) => s.items.length > 0))
+        setSections(next)
+
+        setOpenMap((prev) => {
+          const m = { ...prev }
+          next.forEach(({ date: d }) => {
+            if (typeof m[d] === 'undefined') m[d] = true
+          })
+
+          return m
+        })
       } catch (e) {
         console.error(e)
         setSections([])
@@ -107,10 +117,31 @@ const SettlementBox = ({ mode = 'ALL', date, onItemClick }) => {
     run()
   }, [tripId, mode, date])
 
-  const toggle = (idx) => {
-    setSections((prev) =>
-      prev.map((s, i) => (i === idx ? { ...s, open: !s.open } : s)),
-    )
+  const filteredSections = useMemo(() => {
+    let arr = sections
+
+    if (filterUserId) {
+      const keepMine = (item) => {
+        const payers = Array.isArray(item?.payers) ? item.payers : []
+        const participants = Array.isArray(item?.participants)
+          ? item.participants
+          : []
+        const inPayers = payers.some((p) => (p.userId ?? p.id) === filterUserId)
+        const inParticipants = participants.some((uid) => uid === filterUserId)
+        return inPayers || inParticipants
+      }
+      arr = arr.map((sec) => ({ ...sec, items: sec.items.filter(keepMine) }))
+    }
+
+    if (mode === 'UNSETTLED' || filterUserId) {
+      arr = arr.filter((sec) => sec.items.length > 0)
+    }
+
+    return arr
+  }, [sections, filterUserId, mode])
+
+  const toggle = (dateKey) => {
+    setOpenMap((prev) => ({ ...prev, [dateKey]: !prev[dateKey] }))
   }
 
   if (loading) {
@@ -131,103 +162,150 @@ const SettlementBox = ({ mode = 'ALL', date, onItemClick }) => {
 
   return (
     <div className='flex w-full flex-col gap-4'>
-      {sections.map((sec, idx) => (
-        <div
-          key={sec.date}
-          className='w-full rounded-[20px] bg-white p-3 drop-shadow-sm'
-        >
-          {/* 헤더: 날짜 + 토글 */}
-          <button
-            type='button'
-            onClick={() => toggle(idx)}
-            className='flex w-full items-center justify-between rounded-[12px] border-none bg-white px-3 py-2 text-left outline-none focus:outline-none'
+      {filteredSections.map((sec) => {
+        const isOpen = openMap[sec.date] ?? true
+        return (
+          <div
+            key={sec.date}
+            className='w-full rounded-[20px] bg-white p-3 drop-shadow-sm'
           >
-            <span className='text-[16px] font-medium text-gray-600'>
-              {sec.date || 'Date'}
-            </span>
-            {sec.open ? (
-              <ArrowUp className='text-gray-400' size={18} />
-            ) : (
-              <ArrowDown className='text-gray-400' size={18} />
-            )}
-          </button>
+            <button
+              type='button'
+              onClick={() => toggle(sec.date)}
+              className='flex h-11 w-full items-center justify-between rounded-[12px] border-none bg-white px-3 text-left outline-none focus:outline-none'
+            >
+              <span className='text-[16px] font-medium text-gray-600'>
+                {sec.date || 'Date'}
+              </span>
+              {isOpen ? (
+                <ArrowUp className='text-gray-400' size={18} />
+              ) : (
+                <ArrowDown className='text-gray-400' size={18} />
+              )}
+            </button>
 
-          {/* 내용 */}
-          {sec.open && (
-            <div className='mt-3 flex flex-col gap-2'>
-              {sec.items.map((item) => {
-                const payers = Array.isArray(item?.payers) ? item.payers : []
-                const completed = payers.filter((p) => p?.isCompleted).length
-                const total = payers.length
-                const Icon = typeToIcon(item?.type)
-                const allDone = total > 0 && completed === total
-                const sid = item?.id ?? item?.settlementId
+            {isOpen && (
+              <div className='mt-3 flex flex-col gap-2'>
+                {sec.items.map((item) => {
+                  const payers = Array.isArray(item?.payers) ? item.payers : []
+                  const completed = payers.filter((p) => p?.isCompleted).length
+                  const total = payers.length
+                  const Icon = typeToIcon(item?.type)
+                  const allDone = total > 0 && completed === total
+                  const sid = item?.id ?? item?.settlementId
 
-                return (
-                  <div key={sid} className='relative'>
-                    {/* 카테고리 아이콘: 카드 밖 + 중앙 */}
-                    <div className='absolute top-1/2 left-0 -translate-y-1/2'>
-                      <Icon width={24} height={24} />
-                    </div>
+                  return (
+                    <div key={sid} className='relative'>
+                      <div className='absolute top-1/2 left-0 -translate-y-1/2'>
+                        <Icon width={24} height={24} />
+                      </div>
 
-                    <div
-                      onClick={() => onItemClick?.(sid)}
-                      className='relative ml-9 flex items-start justify-between rounded-[16px] bg-gray-100 px-8 py-5'
-                    >
-                      {/* 본문 */}
-                      <div className='min-w-0 pr-16'>
-                        <div className='text-[12px] text-gray-400'>
-                          {item?.name || '내역 이름'}
-                        </div>
-                        <div className='mt-1 text-[20px] font-bold text-gray-800'>
-                          {formatWon(item?.totalPrice)}원
-                        </div>
+                      <div
+                        onClick={() => onItemClick?.(sid)}
+                        className='relative ml-9 min-h-[96px] rounded-[16px] bg-gray-100 px-8 py-5'
+                      >
+                        <div className='grid grid-cols-[1fr_auto] items-center gap-4'>
+                          <div className='min-w-0'>
+                            <div className='truncate text-[12px] text-gray-400'>
+                              {item?.name || '내역 이름'}
+                            </div>
+                            <div className='mt-1 text-[20px] font-bold text-gray-800'>
+                              {formatWon(item?.totalPrice)}원
+                            </div>
 
-                        {/* 정산 인원: UserIcon + 프로필들 */}
-                        <div className='mt-2 flex items-center gap-2 text-sm text-gray-500'>
-                          <span className='inline-flex items-center gap-2'>
-                            <UserIcon className='text-gray-500' />
-                            <span className='flex items-center gap-1'>
-                              {payers.slice(0, 5).map((p) => (
-                                <Avatar
-                                  key={p.id ?? p.userId}
-                                  url={p.imageUrl}
-                                  name={p.nickname}
-                                  size={23}
-                                />
-                              ))}
-                              {payers.length > 5 && (
-                                <span className='ml-1 rounded-full bg-gray-200 px-1.5 py-0.5 text-[10px] text-gray-600'>
-                                  +{payers.length - 5}
+                            <div className='mt-2 flex min-h-[24px] items-center gap-2 text-sm text-gray-500'>
+                              <span className='inline-flex items-center gap-2'>
+                                <UserIcon className='text-gray-500' />
+                                <span className='flex items-center gap-1'>
+                                  {payers.slice(0, 5).map((p) => (
+                                    <Avatar
+                                      key={p.id ?? p.userId}
+                                      url={p.imageUrl}
+                                      name={p.nickname}
+                                      size={23}
+                                    />
+                                  ))}
+                                  {payers.length > 5 && (
+                                    <span className='ml-1 rounded-full bg-gray-200 px-1.5 py-0.5 text-[10px] text-gray-600'>
+                                      +{payers.length - 5}
+                                    </span>
+                                  )}
                                 </span>
-                              )}
-                            </span>
-                          </span>
+                              </span>
+                            </div>
+                          </div>
+
+                          <div className='self-center'>
+                            {(() => {
+                              const creatorId =
+                                item?.createdById ??
+                                item?.createdBy?.id ??
+                                item?.ownerId ??
+                                item?.owner?.id ??
+                                item?.writerId ??
+                                item?.writer?.id
+
+                              const isMineCreated =
+                                !!myUserId && creatorId === myUserId
+                              const myPayer =
+                                !!myUserId &&
+                                payers.find(
+                                  (p) => (p.userId ?? p.id) === myUserId,
+                                )
+                              const iAmPayer = !!myPayer
+
+                              const showDone =
+                                (isMineCreated && allDone) ||
+                                (iAmPayer && !!myPayer?.isCompleted)
+
+                              const badgeShadow = {
+                                boxShadow: '0 2px 6px rgba(0,0,0,0.05)',
+                              }
+
+                              if (showDone) {
+                                return (
+                                  <span
+                                    className='inline-flex min-w-[45px] items-center justify-center rounded-full bg-gray-300 px-3 py-1 text-center text-xs font-semibold text-white'
+                                    style={badgeShadow}
+                                  >
+                                    완료
+                                  </span>
+                                )
+                              }
+
+                              const pendingBgClass = isMineCreated
+                                ? 'bg-[var(--Blue-Scale-blue-500)]'
+                                : iAmPayer
+                                  ? 'bg-[var(--Grey-Scale-grey-00)]'
+                                  : 'bg-[var(--Blue-Scale-blue-500)]'
+
+                              const textColorClass = pendingBgClass.includes(
+                                'grey-00',
+                              )
+                                ? 'text-[var(--Grey-Scale-grey-300)]'
+                                : 'text-white'
+
+                              return (
+                                <span
+                                  className={`inline-flex min-w-[45px] items-center justify-center rounded-full ${pendingBgClass} ${textColorClass} px-3 py-1 text-center text-xs font-semibold`}
+                                  style={badgeShadow}
+                                >
+                                  {completed}/{total}
+                                </span>
+                              )
+                            })()}
+                          </div>
                         </div>
                       </div>
-
-                      {/* 진행 배지: 완료/전체 */}
-                      <div className='absolute top-1/2 right-3 -translate-y-1/2'>
-                        {allDone ? (
-                          <span className='inline-flex items-center justify-center rounded-full bg-gray-300 px-3 py-1 text-xs font-semibold text-white'>
-                            완료
-                          </span>
-                        ) : (
-                          <span className='inline-flex items-center justify-center rounded-full bg-[var(--Blue-Scale-blue-500)] px-3 py-1 text-xs font-semibold text-white'>
-                            {completed}/{total}
-                          </span>
-                        )}
-                      </div>
                     </div>
-                  </div>
-                )
-              })}
-            </div>
-          )}
-        </div>
-      ))}
+                  )
+                })}
+              </div>
+            )}
+          </div>
+        )
+      })}
     </div>
   )
 }
-
 export default SettlementBox

--- a/src/components/settlement/SettlementBox.jsx
+++ b/src/components/settlement/SettlementBox.jsx
@@ -12,12 +12,23 @@ import SelLodgingIcon from '@/assets/map/category/SelLodgingIcon'
 import SelEtcIcon from '@/assets/map/category/SelEtcIcon'
 import UserIcon from '@/assets/settlement/UserIcon'
 
-function extractGroups(result) {
-  if (!result) return {}
-  if (result.data && typeof result.data === 'object') return result.data
-  return result
+const isUserIncluded = (item, userId) => {
+  if (!userId) return false
+  const payers = Array.isArray(item?.payers) ? item.payers : []
+  const participants = Array.isArray(item?.participants)
+    ? item.participants
+    : []
+  const inPayers = payers.some((p) => (p.userId ?? p.id) === Number(userId))
+  const inParticipants = participants.some(
+    (uid) => Number(uid) === Number(userId),
+  )
+  return inPayers || inParticipants
 }
-
+const isAllDone = (item) => {
+  const payers = Array.isArray(item?.payers) ? item.payers : []
+  if (!payers.length) return false
+  return payers.every((p) => p?.isCompleted === true)
+}
 const normalizeType = (raw) => {
   const v = String(raw || '')
     .trim()
@@ -29,7 +40,6 @@ const normalizeType = (raw) => {
   if (v === 'ETC') return 'ETC'
   return v || 'ETC'
 }
-
 const typeToIcon = (type) => {
   switch (normalizeType(type)) {
     case 'ATTRACTION':
@@ -45,7 +55,6 @@ const typeToIcon = (type) => {
       return SelEtcIcon
   }
 }
-
 const Avatar = ({ url, name, size = 18 }) => {
   const s = `${size}px`
   if (url) {
@@ -69,7 +78,13 @@ const Avatar = ({ url, name, size = 18 }) => {
     </div>
   )
 }
+function extractGroups(result) {
+  if (!result) return {}
+  if (result?.data && typeof result.data === 'object') return result.data
+  return result
+}
 
+/* ===== 메인 ===== */
 const SettlementBox = ({ mode, date, onItemClick, filterUserId, myUserId }) => {
   const { tripId } = useParams()
   const [loading, setLoading] = useState(false)
@@ -85,15 +100,37 @@ const SettlementBox = ({ mode, date, onItemClick, filterUserId, myUserId }) => {
         const groups = extractGroups(result)
 
         let dates = Object.keys(groups).sort((a, b) => a.localeCompare(b))
-        if (mode === 'DAY' && date) {
-          dates = dates.filter((d) => d === date)
-        }
+        if (mode === 'DAY' && date) dates = dates.filter((d) => d === date)
 
         const next = dates.map((d) => {
           let items = Array.isArray(groups[d]) ? groups[d] : []
-          if (mode === 'UNSETTLED') {
-            items = items.filter((it) => it && it.isCompleted === false)
+
+          if (mode === 'DAY') {
+            if (filterUserId) {
+              items = items.filter((it) =>
+                isUserIncluded(it, Number(filterUserId)),
+              )
+            }
           }
+
+          if (mode === 'UNSETTLED') {
+            if (filterUserId) {
+              items = items.filter(
+                (it) =>
+                  isUserIncluded(it, Number(filterUserId)) &&
+                  it?.isCompleted === false,
+              )
+            } else {
+              items = items.filter((it) => it?.isCompleted === false)
+            }
+          } else if (mode === 'ALL') {
+            if (filterUserId) {
+              items = items.filter((it) =>
+                isUserIncluded(it, Number(filterUserId)),
+              )
+            }
+          }
+
           return { date: d, items }
         })
 
@@ -104,7 +141,6 @@ const SettlementBox = ({ mode, date, onItemClick, filterUserId, myUserId }) => {
           next.forEach(({ date: d }) => {
             if (typeof m[d] === 'undefined') m[d] = true
           })
-
           return m
         })
       } catch (e) {
@@ -115,34 +151,18 @@ const SettlementBox = ({ mode, date, onItemClick, filterUserId, myUserId }) => {
       }
     }
     run()
-  }, [tripId, mode, date])
+  }, [tripId, mode, date, filterUserId])
 
   const filteredSections = useMemo(() => {
     let arr = sections
-
-    if (filterUserId) {
-      const keepMine = (item) => {
-        const payers = Array.isArray(item?.payers) ? item.payers : []
-        const participants = Array.isArray(item?.participants)
-          ? item.participants
-          : []
-        const inPayers = payers.some((p) => (p.userId ?? p.id) === filterUserId)
-        const inParticipants = participants.some((uid) => uid === filterUserId)
-        return inPayers || inParticipants
-      }
-      arr = arr.map((sec) => ({ ...sec, items: sec.items.filter(keepMine) }))
-    }
-
     if (mode === 'UNSETTLED' || filterUserId) {
       arr = arr.filter((sec) => sec.items.length > 0)
     }
-
     return arr
-  }, [sections, filterUserId, mode])
+  }, [sections, mode, filterUserId])
 
-  const toggle = (dateKey) => {
+  const toggle = (dateKey) =>
     setOpenMap((prev) => ({ ...prev, [dateKey]: !prev[dateKey] }))
-  }
 
   if (loading) {
     return (
@@ -151,8 +171,7 @@ const SettlementBox = ({ mode, date, onItemClick, filterUserId, myUserId }) => {
       </div>
     )
   }
-
-  if (sections.length === 0) {
+  if (filteredSections.length === 0) {
     return (
       <div className='rounded-[20px] bg-white p-4 text-gray-500 shadow-sm'>
         미정산 내역이 없습니다.
@@ -191,7 +210,6 @@ const SettlementBox = ({ mode, date, onItemClick, filterUserId, myUserId }) => {
                   const completed = payers.filter((p) => p?.isCompleted).length
                   const total = payers.length
                   const Icon = typeToIcon(item?.type)
-                  const allDone = total > 0 && completed === total
                   const sid = item?.id ?? item?.settlementId
 
                   return (
@@ -235,8 +253,24 @@ const SettlementBox = ({ mode, date, onItemClick, filterUserId, myUserId }) => {
                             </div>
                           </div>
 
+                          {/**진행 배지*/}
                           <div className='self-center'>
                             {(() => {
+                              const allDone = isAllDone(item)
+                              const badgeShadow = {
+                                boxShadow: '0 2px 6px rgba(0,0,0,0.05)',
+                              }
+                              if (allDone && item?.isCompleted === true) {
+                                return (
+                                  <span
+                                    className='inline-flex min-w-[45px] items-center justify-center rounded-full bg-gray-300 px-3 py-1 text-center text-xs font-semibold text-white shadow-sm'
+                                    style={badgeShadow}
+                                  >
+                                    완료
+                                  </span>
+                                )
+                              }
+
                               const creatorId =
                                 item?.createdById ??
                                 item?.createdBy?.id ??
@@ -244,7 +278,6 @@ const SettlementBox = ({ mode, date, onItemClick, filterUserId, myUserId }) => {
                                 item?.owner?.id ??
                                 item?.writerId ??
                                 item?.writer?.id
-
                               const isMineCreated =
                                 !!myUserId && creatorId === myUserId
                               const myPayer =
@@ -253,25 +286,6 @@ const SettlementBox = ({ mode, date, onItemClick, filterUserId, myUserId }) => {
                                   (p) => (p.userId ?? p.id) === myUserId,
                                 )
                               const iAmPayer = !!myPayer
-
-                              const showDone =
-                                (isMineCreated && allDone) ||
-                                (iAmPayer && !!myPayer?.isCompleted)
-
-                              const badgeShadow = {
-                                boxShadow: '0 2px 6px rgba(0,0,0,0.05)',
-                              }
-
-                              if (showDone) {
-                                return (
-                                  <span
-                                    className='inline-flex min-w-[45px] items-center justify-center rounded-full bg-gray-300 px-3 py-1 text-center text-xs font-semibold text-white'
-                                    style={badgeShadow}
-                                  >
-                                    완료
-                                  </span>
-                                )
-                              }
 
                               const pendingBgClass = isMineCreated
                                 ? 'bg-[var(--Blue-Scale-blue-500)]'
@@ -287,7 +301,7 @@ const SettlementBox = ({ mode, date, onItemClick, filterUserId, myUserId }) => {
 
                               return (
                                 <span
-                                  className={`inline-flex min-w-[45px] items-center justify-center rounded-full ${pendingBgClass} ${textColorClass} px-3 py-1 text-center text-xs font-semibold`}
+                                  className={`inline-flex min-w-[45px] items-center justify-center rounded-full ${pendingBgClass} ${textColorClass} px-3 py-1 text-center text-xs font-semibold shadow-sm`}
                                   style={badgeShadow}
                                 >
                                   {completed}/{total}
@@ -308,4 +322,5 @@ const SettlementBox = ({ mode, date, onItemClick, filterUserId, myUserId }) => {
     </div>
   )
 }
+
 export default SettlementBox

--- a/src/components/settlement/SettlementTabs.jsx
+++ b/src/components/settlement/SettlementTabs.jsx
@@ -4,17 +4,32 @@ import readTotalSettlementsApi from '@/apis/settlement/readTotalSettlementsApi'
 
 const getDayNumber = (startDateString, currentDateString) => {
   if (!startDateString || !currentDateString) return 0
-
   const startDate = new Date(startDateString)
   const currentDate = new Date(currentDateString)
-
   const diffTime = currentDate.getTime() - startDate.getTime()
   const diffDays = Math.round(diffTime / (1000 * 60 * 60 * 24))
-
   return diffDays + 1
 }
 
-const SettlementTabs = ({ onChange, tripStartDate }) => {
+const isUserIncluded = (item, userId) => {
+  if (!userId) return false
+  const payers = Array.isArray(item?.payers) ? item.payers : []
+  const participants = Array.isArray(item?.participants)
+    ? item.participants
+    : []
+  const inPayers = payers.some((p) => (p.userId ?? p.id) === Number(userId))
+  const inParticipants = participants.some(
+    (uid) => Number(uid) === Number(userId),
+  )
+  return inPayers || inParticipants
+}
+
+const SettlementTabs = ({
+  onChange,
+  tripStartDate,
+  showMineOnly = false,
+  myUserId,
+}) => {
   const { tripId } = useParams()
 
   const [active, setActive] = useState('ALL')
@@ -30,18 +45,23 @@ const SettlementTabs = ({ onChange, tripStartDate }) => {
         const result = await readTotalSettlementsApi(tripId)
         const groups = result?.data ?? {}
 
-        /** 날짜 키 정렬 */
+        // 날짜 키 정렬
         const sortedKeys = Object.keys(groups).sort((a, b) =>
           a.localeCompare(b),
         )
         setDates(sortedKeys)
 
-        /** 미정산 건수 계산 */
-        const allItems = Object.values(groups).flat()
-        const unsettled = allItems.filter(
-          (it) => it && it.isCompleted === false,
-        )
-        setUnsettledCount(unsettled.length)
+        const allItems = Object.values(groups).flat().filter(Boolean)
+
+        const count =
+          showMineOnly && myUserId
+            ? allItems.filter(
+                (it) =>
+                  isUserIncluded(it, myUserId) && it?.isCompleted === false,
+              ).length
+            : allItems.filter((it) => it?.isCompleted === false).length
+
+        setUnsettledCount(count)
       } catch (e) {
         console.error(e)
         setDates([])
@@ -51,7 +71,7 @@ const SettlementTabs = ({ onChange, tripStartDate }) => {
       }
     }
     fetchDates()
-  }, [tripId])
+  }, [tripId, showMineOnly, myUserId])
 
   const handleSelect = (nextActive, date = null) => {
     setActive(nextActive)
@@ -72,7 +92,7 @@ const SettlementTabs = ({ onChange, tripStartDate }) => {
   return (
     <div className='w-full'>
       <div className='flex flex-wrap gap-[6px]'>
-        {/* 미정산 내역, 여행 전체 버튼 (생략) */}
+        {/* 미정산 내역 */}
         <button
           type='button'
           onClick={() => handleSelect('UNSETTLED')}
@@ -84,6 +104,7 @@ const SettlementTabs = ({ onChange, tripStartDate }) => {
           {!loading && unsettledCount > 0 ? ` (${unsettledCount})` : ''}
         </button>
 
+        {/* 여행 전체 */}
         <button
           type='button'
           onClick={() => handleSelect('ALL')}
@@ -94,11 +115,10 @@ const SettlementTabs = ({ onChange, tripStartDate }) => {
           여행 전체
         </button>
 
-        {/** DAY 1 ~ N (Props로 받은 실제 여행 시작일 기준) */}
+        {/* DAY 1 ~ N */}
         {dates.map((date) => {
           const dayNumber = getDayNumber(tripStartDate, date)
           if (dayNumber <= 0) return null
-
           const isActive = active === dayNumber
           return (
             <button

--- a/src/components/settlement/UnsettledTitle.jsx
+++ b/src/components/settlement/UnsettledTitle.jsx
@@ -3,7 +3,11 @@ import { useParams } from 'react-router-dom'
 import readTotalSettlementsApi from '@/apis/settlement/readTotalSettlementsApi'
 
 /** 미정산 내역을 알리는 타이틀 컴포넌트 */
-const UnsettledTitle = ({ showMineOnly = false, onToggleShowMine }) => {
+const UnsettledTitle = ({
+  showMineOnly = false,
+  onToggleShowMine,
+  myUserId,
+}) => {
   const { tripId } = useParams()
   const [count, setCount] = useState(null)
 
@@ -18,9 +22,26 @@ const UnsettledTitle = ({ showMineOnly = false, onToggleShowMine }) => {
           Array.isArray(arr) ? arr : [],
         )
 
-        const unsettledItems = allItems.filter(
+        let unsettledItems = allItems.filter(
           (item) => item && item.isCompleted === false,
         )
+
+        if (showMineOnly && myUserId) {
+          unsettledItems = unsettledItems.filter((item) => {
+            const creatorId = item.payerId
+
+            const payers = Array.isArray(item?.payers) ? item.payers : []
+            const participants = Array.isArray(item?.participants)
+              ? item.participants
+              : []
+
+            const inCreator = creatorId === myUserId
+            const inPayers = payers.some((p) => (p.userId ?? p.id) === myUserId)
+            const inParticipants = participants.some((uid) => uid === myUserId)
+
+            return inCreator || inPayers || inParticipants
+          })
+        }
 
         setCount(unsettledItems.length)
       } catch (err) {
@@ -30,7 +51,7 @@ const UnsettledTitle = ({ showMineOnly = false, onToggleShowMine }) => {
     }
 
     fetchUnSettledCount()
-  }, [tripId])
+  }, [tripId, showMineOnly, myUserId])
 
   return (
     <div className='flex items-end justify-between'>

--- a/src/components/settlement/UnsettledTitle.jsx
+++ b/src/components/settlement/UnsettledTitle.jsx
@@ -3,7 +3,7 @@ import { useParams } from 'react-router-dom'
 import readTotalSettlementsApi from '@/apis/settlement/readTotalSettlementsApi'
 
 /** 미정산 내역을 알리는 타이틀 컴포넌트 */
-const UnsettledTitle = () => {
+const UnsettledTitle = ({ showMineOnly = false, onToggleShowMine }) => {
   const { tripId } = useParams()
   const [count, setCount] = useState(null)
 
@@ -33,16 +33,27 @@ const UnsettledTitle = () => {
   }, [tripId])
 
   return (
-    <div className='text-[28pt] font-bold'>
-      {count !== null ? (
-        <>
-          {count}건의
-          <br />
-          미정산 내역이 있어요
-        </>
-      ) : (
-        '불러오는 중...'
-      )}
+    <div className='flex items-end justify-between'>
+      <h1 className='flex flex-col text-3xl leading-tight font-bold'>
+        {count !== null ? (
+          <>
+            <span>{count}건의</span>
+            <span>미정산 내역이 있어요</span>
+          </>
+        ) : (
+          '불러오는 중...'
+        )}
+      </h1>
+
+      {/** 토글 버튼 */}
+      <button
+        type='button'
+        onClick={onToggleShowMine}
+        className='w-[116px] cursor-pointer border-none bg-transparent text-right text-base text-gray-400 hover:text-gray-500'
+        aria-pressed={showMineOnly}
+      >
+        {showMineOnly ? '전체 정산 보기' : '내 정산만 보기'}
+      </button>
     </div>
   )
 }

--- a/src/index.css
+++ b/src/index.css
@@ -34,3 +34,13 @@
   -ms-overflow-style: none;
   scrollbar-width: none;
 }
+/* 가로 흔들림 방지 */
+html {
+  scrollbar-gutter: stable;
+}
+
+@supports not (scrollbar-gutter: stable) {
+  html {
+    overflow-y: scroll;
+  }
+}

--- a/src/pages/SettlementBook.jsx
+++ b/src/pages/SettlementBook.jsx
@@ -6,13 +6,21 @@ import UnsettledTitle from '@/components/settlement/UnsettledTitle'
 import React, { useEffect, useState } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
 import readTripInfoApi from '@/apis/trip/readTripInfo'
+import useAuth from '@/hooks/useAuth'
 
 const SettlementBook = () => {
   const { tripId } = useParams()
   const navigate = useNavigate()
+  const { user } = useAuth()
+  const currentUserId = user?.id ?? user?.userId
+
   const [view, setView] = useState({ key: 'ALL' })
   const [tripInfo, setTripInfo] = useState(null)
   const [loading, setLoading] = useState(true)
+
+  /**내 정산만 보기 */
+  const [showMineOnly, setShowMineOnly] = useState(false)
+  const toggleShowMineOnly = () => setShowMineOnly((v) => !v)
 
   /** 여행 정보 불러오기 */
   useEffect(() => {
@@ -44,25 +52,30 @@ const SettlementBook = () => {
 
   return (
     <>
-      <div className='flex w-full flex-col pt-5 pb-50'>
+      <div className='flex min-h-screen w-full flex-col overflow-y-auto pt-5 pb-50 [scrollbar-gutter:stable]'>
         <div className='mb-5 flex items-center justify-between px-8'>
           <button className='border-none' onClick={handleBack}>
             <GoBack />
           </button>
         </div>
+
         <div className='flex w-full flex-col gap-8 px-10'>
-          <UnsettledTitle />
+          <UnsettledTitle
+            showMineOnly={showMineOnly}
+            onToggleShowMine={toggleShowMineOnly}
+          />
           {tripInfo?.startedAt && (
             <SettlementTabs
               onChange={setView}
               tripStartDate={tripInfo.startedAt}
             />
           )}
-
           <SettlementBox
             mode={view.key}
             date={view.date}
             onItemClick={handleOpenDetail}
+            filterUserId={showMineOnly ? currentUserId : undefined}
+            myUserId={currentUserId}
           />
           <FixedActionBar className='flex justify-center'>
             <div className='flex w-4xl items-center justify-center rounded-t-[20px] bg-white p-[20px] shadow-[0_0_4px_rgba(0,0,0,0.10)]'>

--- a/src/pages/SettlementBook.jsx
+++ b/src/pages/SettlementBook.jsx
@@ -63,11 +63,14 @@ const SettlementBook = () => {
           <UnsettledTitle
             showMineOnly={showMineOnly}
             onToggleShowMine={toggleShowMineOnly}
+            myUserId={currentUserId}
           />
           {tripInfo?.startedAt && (
             <SettlementTabs
               onChange={setView}
               tripStartDate={tripInfo.startedAt}
+              showMineOnly={showMineOnly}
+              myUserId={currentUserId}
             />
           )}
           <SettlementBox


### PR DESCRIPTION
## 구현 배경

- [IL-380](https://ilmansa.atlassian.net/browse/IL-380) 참고
- 사용자가 `내 정산만 보기` 및 `전체 정산 보기` 를 구분하여 정산 내역을 조회하고자 함

## 작업 사항

- 전체/내 정산 보기 구분 토글 기능 추가
- 미정산 내역 및 날짜별 표시 로직을 사용자 기준으로 분리
 - 미정산 내역 필터링 오류 수정
- UI 및 데이터 일관성 유지 (미정산 탭, 여행 전체, DAY별 뷰 모두 동작 확인)
  - 진행사항 버튼 배경색 구분(내가 만든 정산 / 내가 포함된 다른 사용자가 만든 정산)

<details>
  <summary>전체 정산 보기 UI</summary>

<img width="622" height="626" alt="스크린샷 2025-11-08 오후 11 37 44" src="https://github.com/user-attachments/assets/2e6f497d-9c1d-4813-aaa5-e9cb438fe0ae" />
</details>


<details>
  <summary>내 정산만 보기 UI</summary>

<img width="631" height="465" alt="스크린샷 2025-11-08 오후 11 37 58" src="https://github.com/user-attachments/assets/c2426843-2828-42f8-bdec-d02f63ab82be" />
</details>

## 추가 논의

- [x] 정산 내역 삭제가 제대로 이루어지고 있지 않음 (다음 작업 예정)
  - ~정산자 불일치 오류 발생~
    - 백엔드에 에러 메시지 수정 요청

[IL-380]: https://ilmansa.atlassian.net/browse/IL-380?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ