### PR TITLE
fix(IL-387):  메인페이지 내 추천 여행지 및 인기 여행지 UI 숨기기

### DIFF
--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -118,8 +118,8 @@ const Home = () => {
         loadMore={loadMoreSettingTrips}
         totalElements={settingTripsTotalElements}
       />
-      <RecommendedPlaces user={user} />
-      <TrendingPlaces />
+      {/* <RecommendedPlaces user={user} />
+      <TrendingPlaces /> */}
       <PastTrips pastTrips={pastTrips || []} loadMore={loadMorePastTrips} />
 
       {isCreateTripModalOpen && (

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -118,6 +118,7 @@ const Home = () => {
         loadMore={loadMoreSettingTrips}
         totalElements={settingTripsTotalElements}
       />
+      {/** 추천 여행지 및 인기 여행지 숨기기 */}
       {/* <RecommendedPlaces user={user} />
       <TrendingPlaces /> */}
       <PastTrips pastTrips={pastTrips || []} loadMore={loadMorePastTrips} />


### PR DESCRIPTION
## 구현 배경

- [IL-387](https://ilmansa.atlassian.net/browse/IL-387)  참고
- 이미지 API 관련 이슈로 메인페이지 내 이미지 스팟 관련 부분 렌더링 불가

## 작업 사항

- 관련 부분 주석처리로 UI 숨김 처리
<details>
  <summary>휑한 UI 첨부합니다...</summary>
<img width="442" height="628" alt="스크린샷 2025-11-09 오전 1 08 14" src="https://github.com/user-attachments/assets/1dab2c8d-5ba6-419b-b466-8b84cfe3e529" />
</details>



[IL-387]: https://ilmansa.atlassian.net/browse/IL-387?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ