### PR TITLE
Feature(IL-389): 갤러리 대시보드 여행 전체 탭 구현

### DIFF
--- a/src/apis/image/readGroupedImagesByPlace.jsx
+++ b/src/apis/image/readGroupedImagesByPlace.jsx
@@ -1,0 +1,23 @@
+import api from '@/apis/api'
+
+/**여행 일차별 이미지 조회 API(목적지 id로 그룹화) */
+const readGroupedImagesByPlace = async (tripId, day) => {
+  try {
+    const response = await api.get(
+      `trip/${tripId}/day-place/images/day/${day}/with-place`,
+    )
+    return response.data
+  } catch (err) {
+    if (err.response?.data?.message) {
+      throw err.response.data
+    } else if (err.response) {
+      throw new Error(`오류 발생 (status: ${err.response.status})`)
+    } else if (err.request) {
+      throw new Error('서버로부터 응답이 없습니다.')
+    } else {
+      throw new Error('요청 중 알 수 없는 오류가 발생했습니다.')
+    }
+  }
+}
+
+export default readGroupedImagesByPlace

--- a/src/components/dashboard/gallery/GalleryDashboard.jsx
+++ b/src/components/dashboard/gallery/GalleryDashboard.jsx
@@ -11,10 +11,11 @@ import readPlanningDatePlaceApi from '@/apis/planning-dashboard/readPlanningDate
 import readTemporaryImagesApi from '@/apis/image/readTemporaryImagesApi'
 import readMatchedImagesApi from '@/apis/image/readMatchedImagesApi'
 import readUnmatchedImagesApi from '@/apis/image/readUnmatchedImagesApi'
+import readGroupedImagesByPlace from '@/apis/image/readGroupedImagesByPlace'
 import deleteTemporaryImagesApi from '@/apis/image/deleteTemporaryImagesApi'
 import matchTemporaryImagesApi from '@/apis/image/matchTemporaryImagesApi'
-import deleteSingleImageApi from '@/apis/image/deleteSingleImageApi' // Import deleteSingleImageApi
-import updateFavoriteImageApi from '@/apis/image/updateFavoriteImageApi' // Import updateFavoriteImageApi
+import deleteSingleImageApi from '@/apis/image/deleteSingleImageApi'
+import updateFavoriteImageApi from '@/apis/image/updateFavoriteImageApi'
 import { Link2, Trash2, Heart, Share2, Download } from 'lucide-react'
 import Spinner from '@/assets/common/Spinner'
 
@@ -27,15 +28,13 @@ const GalleryDashBoard = ({ activeTab }) => {
   const [temporaryImages, setTemporaryImages] = useState([])
   const [matchedImages, setMatchedImages] = useState([])
   const [unmatchedImages, setUnmatchedImages] = useState([])
-
-  // Selection states
   const [isTempSelectionMode, setIsTempSelectionMode] = useState(false)
   const [selectedTempImages, setSelectedTempImages] = useState({
     imageIds: [],
     urls: [],
   })
   const [isAlbumSelectionMode, setIsAlbumSelectionMode] = useState(false)
-  const [selectedAlbumImages, setSelectedAlbumImages] = useState([]) // Changed to array of objects
+  const [selectedAlbumImages, setSelectedAlbumImages] = useState([])
 
   const [isUploading, setIsUploading] = useState(false)
   const [uploadCount, setUploadCount] = useState(0)
@@ -120,11 +119,68 @@ const GalleryDashBoard = ({ activeTab }) => {
     }
   }, [activeDay, planningPlaces, tripId])
 
+  const fetchAllDaysImages = useCallback(async () => {
+    if (!tripInfo || !planningPlaces.length) return
+
+    try {
+      const tripDuration =
+        (new Date(tripInfo.endedAt) - new Date(tripInfo.startedAt)) /
+          (1000 * 60 * 60 * 24) +
+        1
+      const dayPromises = Array.from({ length: tripDuration }, (_, i) =>
+        readGroupedImagesByPlace(tripId, i + 1),
+      )
+      const results = await Promise.all(dayPromises)
+
+      const allImages = []
+      results.forEach((result, index) => {
+        const tripDayPlaceId = planningPlaces[index]?.id
+        if (result.data) {
+          result.data.byPlace.forEach((place) => {
+            allImages.push(
+              ...place.images.map((image) => ({
+                ...image,
+                placeId: place.placeId,
+                tripDayPlaceId,
+              })),
+            )
+          })
+          if (result.data.unmatched) {
+            allImages.push(
+              ...result.data.unmatched.map((image) => ({
+                ...image,
+                placeId: null,
+                tripDayPlaceId,
+              })),
+            )
+          }
+        }
+      })
+
+      setMatchedImages([{ id: 'all-days', name: '전체', images: allImages }])
+      setUnmatchedImages([])
+    } catch (err) {
+      console.error('Failed to fetch all images:', err)
+      setMatchedImages([])
+      setUnmatchedImages([])
+    }
+  }, [tripId, tripInfo, planningPlaces])
+
   useEffect(() => {
+    if (activeDay === 0) {
+      fetchAllDaysImages()
+    } else {
+      fetchMatchedImages()
+      fetchUnmatchedImages()
+    }
     fetchTemporaryImages()
-    fetchMatchedImages()
-    fetchUnmatchedImages()
-  }, [fetchTemporaryImages, fetchMatchedImages, fetchUnmatchedImages])
+  }, [
+    activeDay,
+    fetchTemporaryImages,
+    fetchMatchedImages,
+    fetchUnmatchedImages,
+    fetchAllDaysImages,
+  ])
 
   /**임시저장 이미지 선택 모드 */
   const toggleTempSelectionMode = () => {
@@ -184,7 +240,12 @@ const GalleryDashBoard = ({ activeTab }) => {
       } else {
         return [
           ...prev,
-          { id: image.id, url: image.url, placeId: image.placeId },
+          {
+            id: image.id,
+            url: image.url,
+            placeId: image.placeId,
+            tripDayPlaceId: image.tripDayPlaceId,
+          },
         ]
       }
     })
@@ -202,8 +263,11 @@ const GalleryDashBoard = ({ activeTab }) => {
     }
 
     try {
-      const tripDayPlaceId = planningPlaces[activeDay - 1].id
       const deletePromises = selectedAlbumImages.map(async (image) => {
+        const tripDayPlaceId =
+          activeDay > 0
+            ? planningPlaces[activeDay - 1].id
+            : image.tripDayPlaceId
         const body = image.placeId
           ? {
               url: image.url,
@@ -238,8 +302,11 @@ const GalleryDashBoard = ({ activeTab }) => {
     }
 
     try {
-      const tripDayPlaceId = planningPlaces[activeDay - 1].id
       const favoritePromises = selectedAlbumImages.map(async (image) => {
+        const tripDayPlaceId =
+          activeDay > 0
+            ? planningPlaces[activeDay - 1].id
+            : image.tripDayPlaceId
         const body = image.placeId
           ? { placeId: image.placeId, favorite: newFavoriteStatus }
           : { favorite: newFavoriteStatus }
@@ -368,8 +435,12 @@ const GalleryDashBoard = ({ activeTab }) => {
 
   /**전체 데이터 새로고침 */
   const onImageAction = () => {
-    fetchMatchedImages()
-    fetchUnmatchedImages()
+    if (activeDay === 0) {
+      fetchAllDaysImages()
+    } else {
+      fetchMatchedImages()
+      fetchUnmatchedImages()
+    }
     fetchTemporaryImages()
   }
 

--- a/src/components/dashboard/gallery/PhotoAlbum.jsx
+++ b/src/components/dashboard/gallery/PhotoAlbum.jsx
@@ -43,14 +43,13 @@ const PhotoAlbum = ({
       place.images.map((image) => ({
         ...image,
         placeName: place.name,
-        placeId: place.id,
       })),
     )
     .concat(unmatchedImages.map((image) => ({ ...image, placeName: '기타' })))
 
   const openModal = (image, place) => {
     if (isAlbumSelectionMode) {
-      handleAlbumImageClick({ ...image, placeId: place ? place.id : null })
+      handleAlbumImageClick(image)
       return
     }
     const imageWithPlace = allImagesForModal.find((img) => img.id === image.id)
@@ -118,7 +117,13 @@ const PhotoAlbum = ({
       : { favorite: newIsFavorite }
 
     try {
-      await updateFavoriteImageApi(tripId, tripDayPlaceId, modalImage.id, body)
+      const tripDayPlaceIdForApi = modalImage.tripDayPlaceId || tripDayPlaceId
+      await updateFavoriteImageApi(
+        tripId,
+        tripDayPlaceIdForApi,
+        modalImage.id,
+        body,
+      )
       alert(
         newIsFavorite
           ? '즐겨찾기에 추가되었습니다.'
@@ -143,7 +148,13 @@ const PhotoAlbum = ({
       : { url: modalImage.url, deleteType: 'UNMATCHED' }
 
     try {
-      await deleteSingleImageApi(tripId, tripDayPlaceId, modalImage.id, body)
+      const tripDayPlaceIdForApi = modalImage.tripDayPlaceId || tripDayPlaceId
+      await deleteSingleImageApi(
+        tripId,
+        tripDayPlaceIdForApi,
+        modalImage.id,
+        body,
+      )
       alert('삭제되었습니다')
       showNextImage()
       onImageAction()


### PR DESCRIPTION
## 구현 배경
- [IL-389](https://ilmansa.atlassian.net/browse/IL-389)
- 갤러리 대시보드에서 여행에 저장된 전체 사진을 불러오기 위함

## 작업 사항
- **여행 일차별 이미지 조회 API 구현(47e7f6ace05bddd4524f8eac183a3b2c72812899)**
- **갤러리 대시보드 내 `여행 전체` 탭 구현(d514cd0a4c6d5bca33f504fa79afe41cb6ec12d8)**

[IL-389]: https://ilmansa.atlassian.net/browse/IL-389?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ