### PR TITLE
Feature(IL-394): 아이디 찾기 페이지 UI 및 API 연동

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -23,6 +23,8 @@ import SettlementDetail from './pages/SettlementDetail'
 import RallyMap from './pages/RallyMap'
 import RallyPointViewer from './pages/RallyPointViewer'
 import SettlementEdit from './pages/SettlementEdit'
+import FindId from './pages/FindId'
+import FindIdResult from './pages/FindIdResult'
 
 const App = () => {
   return (
@@ -38,7 +40,8 @@ const App = () => {
             <Route path='signup/guest' element={<GuestSignUp />} />
             {/* TODO: 추후 페이지 변경 예정 */}
             <Route path='restore/account' element={<RestoreAccount />} />
-
+            <Route path='user/help/id' element={<FindId />} />
+            <Route path='user/help/id/result' element={<FindIdResult />} />
             {/* 보호된 비공개 라우트 */}
             <Route element={<ProtectedRoute />}>
               <Route path='/' element={<Home />} />

--- a/src/apis/authentication/findIdApi.jsx
+++ b/src/apis/authentication/findIdApi.jsx
@@ -1,0 +1,21 @@
+import api from '@/apis/api'
+
+/**아이디 찾기 API */
+const findIdApi = async (body) => {
+  try {
+    const response = await api.post('auth/id-inquiry', body)
+    return response.data
+  } catch (err) {
+    if (err.response?.data?.message) {
+      throw new Error(err.response.data.message)
+    } else if (err.response) {
+      throw new Error(`오류 발생 (status: ${err.response.status})`)
+    } else if (err.request) {
+      throw new Error('서버로부터 응답이 없습니다.')
+    } else {
+      throw new Error('요청 중 알 수 없는 오류가 발생했습니다.')
+    }
+  }
+}
+
+export default findIdApi

--- a/src/assets/common/Check.jsx
+++ b/src/assets/common/Check.jsx
@@ -1,0 +1,22 @@
+/**체크 아이콘 컴포넌트 */
+const Check = () => {
+  return (
+    <svg
+      width='18'
+      height='13'
+      viewBox='0 0 18 13'
+      fill='none'
+      xmlns='http://www.w3.org/2000/svg'
+    >
+      <path
+        d='M17 1L11.5 6.5L6 12L1 7'
+        stroke='#313131'
+        stroke-width='2'
+        stroke-linecap='round'
+        stroke-linejoin='round'
+      />
+    </svg>
+  )
+}
+
+export default Check

--- a/src/components/sign-in/SignInForm.jsx
+++ b/src/components/sign-in/SignInForm.jsx
@@ -78,7 +78,8 @@ const SignInForm = () => {
 
           {/* 각종 버튼 */}
           <div className='mx-auto my-[50px] text-lg text-[var(--Grey-Scale-grey-300)]'>
-            <Link>아이디 찾기</Link>&nbsp;|&nbsp;<Link>비밀번호 찾기</Link>
+            <Link to={'/user/help/id'}>아이디 찾기</Link>&nbsp;|&nbsp;
+            <Link>비밀번호 찾기</Link>
             &nbsp;|&nbsp;<Link to={'/signup'}>회원가입하기</Link>
           </div>
         </div>

--- a/src/pages/FindId.jsx
+++ b/src/pages/FindId.jsx
@@ -1,0 +1,81 @@
+import findIdApi from '@/apis/authentication/findIdApi'
+import GoBack from '@/assets/sign-up/GoBack'
+import React, { useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+
+/** 아이디 찾기 페이지 */
+const FindId = () => {
+  const navigate = useNavigate()
+  const [email, setEmail] = useState('')
+
+  const findIdClick = async (e) => {
+    e.preventDefault()
+    try {
+      const body = { email }
+      const response = await findIdApi(body)
+
+      if (response?.code === 200) {
+        const username = response.data.username
+        navigate('/user/help/id/result', { state: { username } })
+      } else {
+        alert(response?.message || '아이디를 찾을 수 없습니다.')
+      }
+    } catch (error) {
+      console.error(error)
+      alert('아이디 찾기 중 오류가 발생했습니다.')
+    }
+  }
+
+  return (
+    <div className='flex w-full flex-col pt-5'>
+      <div>
+        <button
+          className='text-bold my-5 border-none px-8'
+          onClick={() => navigate('/signin')}
+        >
+          <GoBack />
+        </button>
+      </div>
+
+      <div className='mb-15 px-10'>
+        <div className='text-4xl/[1.4] font-bold text-[var(--Grey-Scale-grey-400)]'>
+          아이디 찾기에 사용할
+          <br />
+          이메일을 입력해주세요
+        </div>
+        <div className='text-lg/[2] text-[var(--Grey-Scale-grey-300)]'>
+          입력하신 이메일로 가입된 아이디를 안내해드릴게요
+        </div>
+      </div>
+
+      <form
+        onSubmit={findIdClick}
+        className='flex h-full w-full flex-col items-center px-10'
+      >
+        <div className='mb-[30px] flex w-full flex-col justify-between gap-2'>
+          <label className='text-xl'>이메일</label>
+          <input
+            placeholder='이메일을 입력해주세요'
+            type='email'
+            className='border-none bg-gray-100 p-[20px] text-xl'
+            onChange={(e) => setEmail(e.target.value)}
+            required
+          />
+        </div>
+
+        <div className='fixed bottom-0 left-0 flex w-full flex-col items-center gap-[20px]'>
+          <div className='flex w-4xl items-center justify-center rounded-t-[20px] p-[20px] shadow-[0_0_4px_rgba(0,0,0,0.10)]'>
+            <button
+              type='submit'
+              className='w-full border-none bg-[var(--Blue-Scale-blue-500)] p-[20px] text-2xl text-white'
+            >
+              아이디 찾기
+            </button>
+          </div>
+        </div>
+      </form>
+    </div>
+  )
+}
+
+export default FindId

--- a/src/pages/FindIdResult.jsx
+++ b/src/pages/FindIdResult.jsx
@@ -1,0 +1,55 @@
+import GoBack from '@/assets/sign-up/GoBack'
+import { Check } from 'lucide-react'
+import { useLocation, useNavigate } from 'react-router-dom'
+
+/** 아이디 찾기 결과 페이지 */
+const FindIdResult = () => {
+  const navigate = useNavigate()
+  const location = useLocation()
+  const username = location.state.username
+
+  return (
+    <div className='flex w-full flex-col pt-5'>
+      {/* 뒤로 가기 버튼 */}
+      <div>
+        <button
+          className='text-bold my-5 border-none px-8'
+          onClick={() => navigate(-1)}
+        >
+          <GoBack />
+        </button>
+      </div>
+
+      <div className='mt-[280px] flex h-screen flex-col items-center justify-start'>
+        <Check className='mb-6 h-15 w-15 text-[var(--Blue-Scale-blue-500)]' />
+
+        {username ? (
+          <h2 className='mb-6 text-center text-3xl leading-relaxed font-bold'>
+            가입하신 아이디는
+            <br />
+            <span className='font-medium text-[var(--Blue-Scale-blue-500)]'>
+              {username}
+            </span>{' '}
+            입니다.
+          </h2>
+        ) : (
+          <p className='mb-8 text-center text-xl text-red-500'>
+            아이디 정보를 불러올 수 없습니다.
+          </p>
+        )}
+      </div>
+      <div className='fixed bottom-0 left-0 flex w-full flex-col items-center gap-[20px]'>
+        <div className='flex w-4xl items-center justify-center rounded-t-[20px] p-[20px] shadow-[0_0_4px_rgba(0,0,0,0.10)]'>
+          <button
+            onClick={() => navigate('/signin')}
+            className='w-full border-none bg-[var(--Blue-Scale-blue-500)] p-[20px] text-2xl text-white'
+          >
+            로그인 화면으로 이동하기
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default FindIdResult


### PR DESCRIPTION
## 구현 배경

- [IL-394](https://ilmansa.atlassian.net/browse/IL-394) 참고
- 사용자가 이메일을 통해 서비스에 가입한 아이디를 찾고자 함

## 작업 사항

- 아이디 찾기 API 연동
- 아이디 찾기 페이지 구현
- 아이디 찾기 결과 페이지 구현
- 페이지 라우팅
<details>
  <summary>UI 🥸</summary>
<img width="450" height="736" alt="스크린샷 2025-11-13 오전 12 26 39" src="https://github.com/user-attachments/assets/6399d3fc-0b73-4f19-93a1-a25403aaf26c" />

<img width="448" height="738" alt="스크린샷 2025-11-13 오전 12 26 51" src="https://github.com/user-attachments/assets/dae8d0b4-b979-4ecc-8fa0-d869aa5a900a" />
</details>

## 추가 논의

- 다음 작업부턴 분리하여 PR 올리겠읍니다 ㅜ,ㅜ
- 보안이슈로 **아이디 마스킹 작업**을 해볼까 합니다


[IL-394]: https://ilmansa.atlassian.net/browse/IL-394?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ