### PR TITLE
Feature(IL-397): 아이디 마스킹 적용

### DIFF
--- a/src/components/sign-in/utils/MaskUserName.jsx
+++ b/src/components/sign-in/utils/MaskUserName.jsx
@@ -1,0 +1,28 @@
+/**아이디 마스킹 유틸 */
+export function maskUsername(username, options = {}) {
+  if (!username || typeof username !== 'string') return ''
+
+  const { visibleStart = 2, visibleEnd = 2, maskChar = '*' } = options
+
+  const mask = (s) => {
+    const len = s.length
+    if (len <= visibleStart) return s[0] + maskChar.repeat(Math.max(len - 1, 0))
+    if (len <= visibleStart + visibleEnd) {
+      const start = s.slice(0, visibleStart)
+      return start + maskChar.repeat(Math.max(len - visibleStart, 0))
+    }
+    const start = s.slice(0, visibleStart)
+    const end = s.slice(-visibleEnd)
+    const maskedLen = Math.max(len - visibleStart - visibleEnd, 0)
+    return `${start}${maskChar.repeat(maskedLen)}${end}`
+  }
+
+  const at = username.indexOf('@')
+  if (at > 0) {
+    const local = username.slice(0, at)
+    const domain = username.slice(at)
+    return `${mask(local)}${domain}`
+  }
+
+  return mask(username)
+}

--- a/src/pages/FindIdResult.jsx
+++ b/src/pages/FindIdResult.jsx
@@ -1,6 +1,7 @@
 import GoBack from '@/assets/sign-up/GoBack'
 import { Check } from 'lucide-react'
 import { useLocation, useNavigate } from 'react-router-dom'
+import { maskUsername } from '@/components/sign-in/utils/MaskUserName'
 
 /** 아이디 찾기 결과 페이지 */
 const FindIdResult = () => {
@@ -28,7 +29,7 @@ const FindIdResult = () => {
             가입하신 아이디는
             <br />
             <span className='font-medium text-[var(--Blue-Scale-blue-500)]'>
-              {username}
+              {maskUsername(username)}
             </span>{' '}
             입니다.
           </h2>


### PR DESCRIPTION
## 구현 배경

- [IL-397](https://ilmansa.atlassian.net/browse/IL-397) 참고
- 사용자가 찾은 아이디를 마스킹하여 보여주고자 함(보안)

## 작업 사항

- 마스킹 유틸 함수 구현
- 마스킹 적용
 <details>
  <summary>마스킹 규칙</summary>

- 일반 아이디(abcd1234)의 경우
  - 앞 2글자(ab) + 뒤 2글자(34)는 보이게 나머지 가운데(cd12)는 *로 가림 
  → 결과: ab****34
- 짧은 아이디(ab12)의 경우
  - 전체 길이가 4 이하라면 앞 2글자만 남기고 나머지 전부 *
→ 결과: ab**
- 이메일(user@example.com)의 경우
  - @ 앞 부분(local part)만 마스킹
@example.com은 그대로 유지
→ 결과: us****@example.com
</details>
<details>
  <summary>UI 🤳 </summary>
<img width="446" height="734" alt="스크린샷 2025-11-13 오전 12 58 12" src="https://github.com/user-attachments/assets/c348c319-9606-4992-aa11-fdcb878b0696" />
</details>




[IL-397]: https://ilmansa.atlassian.net/browse/IL-397?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ