### PR TITLE
Feature(IL-398): 일정 대시보드 내 전체 목적지 확정 후 지도 보기 기능 (여행 전체)

### DIFF
--- a/src/components/dashboard/schedule/DayTabs.jsx
+++ b/src/components/dashboard/schedule/DayTabs.jsx
@@ -142,6 +142,8 @@ const DayTabs = ({ tripInfo, activeTab, onContentUpdate }) => {
                 focusOnSelected={false}
                 showFixedActionBar={false}
                 initialZoom={10}
+                dayFilter={activeDayTab === 0 ? 'all' : activeDayTab}
+                onMapClick={() => navigate(`/trip/${tripId}/map`)}
               />
             </div>
           </>

--- a/src/components/dashboard/schedule/DayTabs.jsx
+++ b/src/components/dashboard/schedule/DayTabs.jsx
@@ -11,6 +11,7 @@ import readPlanningDatePlaceApi from '@/apis/planning-dashboard/readPlanningDate
 import NoticeCreateModal from '../modal/NoticeCreateModal'
 import createNoticeApi from '@/apis/notice/createNoticeApi'
 import PointPinIcon from '@/assets/dashboard/PointPinIcon'
+import TripPlaceMap from '@/pages/TripPlaceMap'
 
 const DayTabs = ({ tripInfo, activeTab, onContentUpdate }) => {
   const [activeDayTab, setActiveDayTab] = useState(0)
@@ -132,6 +133,19 @@ const DayTabs = ({ tripInfo, activeTab, onContentUpdate }) => {
             </div>
           ))}
         </div>
+        {/* 목적지 확정 후 지도 영역 */}
+        {tripInfo.status !== 'SETTING' && (
+          <>
+            <div className='mt-5 mb-4 h-[260px] overflow-hidden rounded-2xl'>
+              <TripPlaceMap
+                showBackButton={false}
+                focusOnSelected={false}
+                showFixedActionBar={false}
+                initialZoom={10}
+              />
+            </div>
+          </>
+        )}
 
         <div className='mt-4 flex flex-col gap-3 pb-[120px]'>
           {tripInfo.status === 'SETTING'

--- a/src/pages/TripPlaceMap.jsx
+++ b/src/pages/TripPlaceMap.jsx
@@ -72,7 +72,12 @@ ImageOverlay.prototype.getPosition = function () {
 }
 
 /** 저장된 목적지들을 보여주는 지도 화면 */
-const TripPlaceMap = () => {
+const TripPlaceMap = ({
+  showBackButton = true,
+  focusOnSelected = true,
+  showFixedActionBar = true,
+  initialZoom = 16,
+}) => {
   const navigate = useNavigate()
   const { tripInfo } = useTripInfo()
   const tripId = tripInfo?.tripId
@@ -161,7 +166,7 @@ const TripPlaceMap = () => {
     const initMap = (lat, lng) => {
       const mapOptions = {
         center: new window.naver.maps.LatLng(lat, lng),
-        zoom: 16,
+        zoom: initialZoom,
         minZoom: 7,
         zoomControl: true,
         zoomControlOptions: {
@@ -202,7 +207,7 @@ const TripPlaceMap = () => {
     } else if (window.naver && window.naver.maps) {
       startMapInit()
     }
-  }, [places, isLoading])
+  }, [places, isLoading, initialZoom])
 
   const filteredPlaces = useMemo(
     () => places.filter((p) => dayFilter === 'all' || p.day === dayFilter),
@@ -222,7 +227,6 @@ const TripPlaceMap = () => {
   useEffect(() => {
     if (!map) return
 
-    // 이전 마커들 제거
     markersRef.current.forEach((marker) => marker.setMap(null))
     markersRef.current = []
 
@@ -253,7 +257,18 @@ const TripPlaceMap = () => {
     })
 
     markersRef.current = newMarkers
-  }, [map, filteredPlaces])
+
+    // 선택된 장소에 포커싱하지 않을 때(임베디드 지도) : 모든 마커가 보이도록 지도 범위 조정
+    if (!focusOnSelected && filteredPlaces.length > 0) {
+      const bounds = new window.naver.maps.LatLngBounds()
+      filteredPlaces.forEach((place) => {
+        bounds.extend(
+          new window.naver.maps.LatLng(place.latitude, place.longitude),
+        )
+      })
+      map.fitBounds(bounds)
+    }
+  }, [map, filteredPlaces, focusOnSelected])
 
   // 이미지 오버레이 관리
   useEffect(() => {
@@ -305,19 +320,17 @@ const TripPlaceMap = () => {
     }
   }, [map, selectedPlace])
 
-  // 지도 뷰 조정
+  //  선택된 장소로 지도 포커스
   useEffect(() => {
-    if (map && selectedPlace) {
-      map.panTo(
-        new window.naver.maps.LatLng(
-          selectedPlace.latitude,
-          selectedPlace.longitude,
-        ),
-      )
-      map.setZoom(16, true)
-    }
-  }, [map, selectedPlace])
-
+    if (!map || !selectedPlace || !focusOnSelected) return
+    map.panTo(
+      new window.naver.maps.LatLng(
+        selectedPlace.latitude,
+        selectedPlace.longitude,
+      ),
+    )
+    map.setZoom(16, true)
+  }, [map, selectedPlace, focusOnSelected])
   const goToPreviousPlace = () => {
     if (filteredPlaces.length > 0) {
       const newIndex =
@@ -351,14 +364,16 @@ const TripPlaceMap = () => {
 
   return (
     <div className='relative h-full w-full'>
-      <div className='absolute top-4 left-4 z-10 flex items-center'>
-        <button
-          className='text-bold my-5 border-none px-8'
-          onClick={() => navigate(-1)}
-        >
-          <GoBack />
-        </button>
-      </div>
+      {showBackButton && (
+        <div className='absolute top-4 left-4 z-10 flex items-center'>
+          <button
+            className='text-bold my-5 border-none px-8'
+            onClick={() => navigate(-1)}
+          >
+            <GoBack />
+          </button>
+        </div>
+      )}
 
       <div
         id='map'
@@ -370,7 +385,7 @@ const TripPlaceMap = () => {
         </div>
       )}
 
-      {!isLoading && places.length > 0 && (
+      {!isLoading && places.length > 0 && showFixedActionBar && (
         <FixedActionBar className='flex justify-center'>
           <div className='w-4xl rounded-t-[20px] bg-white p-2 shadow-[0_0_4px_rgba(0,0,0,0.10)]'>
             <div className='flex flex-wrap gap-[6px] p-3'>

--- a/src/pages/TripPlaceMap.jsx
+++ b/src/pages/TripPlaceMap.jsx
@@ -77,6 +77,8 @@ const TripPlaceMap = ({
   focusOnSelected = true,
   showFixedActionBar = true,
   initialZoom = 16,
+  dayFilter: externalDayFilter,
+  onMapClick,
 }) => {
   const navigate = useNavigate()
   const { tripInfo } = useTripInfo()
@@ -90,6 +92,9 @@ const TripPlaceMap = ({
   const [currentIndex, setCurrentIndex] = useState(0)
   const [dayFilter, setDayFilter] = useState('all')
   const [isLoading, setIsLoading] = useState(true)
+
+  const effectiveDayFilter =
+    externalDayFilter === undefined ? dayFilter : externalDayFilter
 
   // 여행 정보 및 장소들 가져오기
   useEffect(() => {
@@ -174,6 +179,13 @@ const TripPlaceMap = ({
         },
       }
       const mapInstance = new window.naver.maps.Map('map', mapOptions)
+
+      if (onMapClick) {
+        window.naver.maps.Event.addListener(mapInstance, 'click', () => {
+          onMapClick()
+        })
+      }
+
       setMap(mapInstance)
     }
 
@@ -183,7 +195,6 @@ const TripPlaceMap = ({
           const firstPlace = places[0]
           initMap(firstPlace.latitude, firstPlace.longitude)
         } else {
-          // Fallback if no places
           if (navigator.geolocation) {
             navigator.geolocation.getCurrentPosition(
               (position) =>
@@ -207,11 +218,14 @@ const TripPlaceMap = ({
     } else if (window.naver && window.naver.maps) {
       startMapInit()
     }
-  }, [places, isLoading, initialZoom])
+  }, [places, isLoading, initialZoom, onMapClick])
 
   const filteredPlaces = useMemo(
-    () => places.filter((p) => dayFilter === 'all' || p.day === dayFilter),
-    [places, dayFilter],
+    () =>
+      places.filter(
+        (p) => effectiveDayFilter === 'all' || p.day === effectiveDayFilter,
+      ),
+    [places, effectiveDayFilter],
   )
 
   useEffect(() => {
@@ -221,7 +235,7 @@ const TripPlaceMap = ({
     } else {
       setSelectedPlace(null)
     }
-  }, [dayFilter, places, filteredPlaces])
+  }, [effectiveDayFilter, filteredPlaces])
 
   // 지도에 장소 마커 표시
   useEffect(() => {
@@ -282,7 +296,7 @@ const TripPlaceMap = ({
       selectedPlace.images &&
       selectedPlace.images.length > 0
     ) {
-      const radius = 100 // 핀으로부터의 거리
+      const radius = 100
       const imagesToShow = selectedPlace.images.slice(0, 5)
       const numImages = imagesToShow.length
 
@@ -290,7 +304,7 @@ const TripPlaceMap = ({
       container.style.position = 'relative'
 
       imagesToShow.forEach((image, i) => {
-        const angle = (i * (360 / numImages) - 90) * (Math.PI / 180) // 위쪽부터 시작
+        const angle = (i * (360 / numImages) - 90) * (Math.PI / 180)
         const x = radius * Math.cos(angle)
         const y = radius * Math.sin(angle)
 
@@ -305,7 +319,7 @@ const TripPlaceMap = ({
         img.style.border = '2px solid white'
         img.style.boxShadow = '0 2px 5px rgba(0,0,0,0.3)'
         img.style.transform = 'translate(-50%, -50%)'
-        img.style.boxSizing = 'content-box' // 너비 문제 해결
+        img.style.boxSizing = 'content-box'
         container.appendChild(img)
       })
 
@@ -320,7 +334,7 @@ const TripPlaceMap = ({
     }
   }, [map, selectedPlace])
 
-  //  선택된 장소로 지도 포커스
+  // 선택된 장소로 지도 포커스
   useEffect(() => {
     if (!map || !selectedPlace || !focusOnSelected) return
     map.panTo(
@@ -331,6 +345,7 @@ const TripPlaceMap = ({
     )
     map.setZoom(16, true)
   }, [map, selectedPlace, focusOnSelected])
+
   const goToPreviousPlace = () => {
     if (filteredPlaces.length > 0) {
       const newIndex =
@@ -379,6 +394,7 @@ const TripPlaceMap = ({
         id='map'
         className={`h-full w-full ${isLoading ? 'invisible' : ''}`}
       ></div>
+
       {isLoading && (
         <div className='bg-opacity-50 absolute inset-0 flex items-center justify-center bg-white'>
           <p>Loading map...</p>
@@ -391,7 +407,7 @@ const TripPlaceMap = ({
             <div className='flex flex-wrap gap-[6px] p-3'>
               {tabs.map((tab, index) => {
                 const day = index === 0 ? 'all' : index
-                const isActive = dayFilter === day
+                const isActive = effectiveDayFilter === day
                 return (
                   <div
                     key={tab}


### PR DESCRIPTION
## 구현 배경

- [IL-398](https://ilmansa.atlassian.net/browse/IL-398) 참고
- 사용자가 목적지 확정 후 일정 대시보드 내에서 목적지를 담은 지도를 조회하고자 함

## 작업 사항

- 일정 대시보드 내 확정된 목적지 지도에 렌더링
- 날짜별 목적지 지도 렌더링
- 지도 클릭 시 `/trip/${tripId}/map` 페이지로 이동
 
<details>
  <summary>일정 대시보드 UI</summary>
<img width="426" height="429" alt="스크린샷 2025-11-15 오후 12 59 50" src="https://github.com/user-attachments/assets/b28f8a15-c272-4653-983f-32a49805aace" />

<img width="432" height="396" alt="스크린샷 2025-11-15 오후 1 00 06" src="https://github.com/user-attachments/assets/7df1d988-cfe3-4da3-9990-516c25247d99" />
</details>

## 추가 논의
 
- 핵심 로직이라 amplify로 꼭 확인 부탁드립니다‼️

[IL-398]: https://ilmansa.atlassian.net/browse/IL-398?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ